### PR TITLE
修复滚动定位问题

### DIFF
--- a/src/Nav.jsx
+++ b/src/Nav.jsx
@@ -216,14 +216,10 @@ const Nav = React.createClass({
       const activeTabOffset = this.getOffsetLT(activeTab);
       if (wrapOffset > activeTabOffset) {
         offset += (wrapOffset - activeTabOffset);
-        this.setState({
-          offset,
-        });
+        this.setOffset(offset);
       } else if ((wrapOffset + navWrapNodeWH) < (activeTabOffset + activeTabWH)) {
         offset -= (activeTabOffset + activeTabWH) - (wrapOffset + navWrapNodeWH);
-        this.setState({
-          offset,
-        });
+        this.setOffset(offset);
       }
     }
   },


### PR DESCRIPTION
重现前提：有滚动
- 用外部操作触发activeKey变化 可重现
- 滚动后来回反复点击两个tab可重现

相关issue：https://github.com/ant-design/ant-design/issues/2676