### PR TITLE
chore: add wrapper for backward-compatibility

### DIFF
--- a/assets/index/common.less
+++ b/assets/index/common.less
@@ -125,8 +125,11 @@
       overflow: auto;
     }
 
-    &-animated {
+    &-wrapper {
       transition: transform @effect-duration @easing-in-out;
+    }
+
+    &-animated {
       display: flex;
       will-change: transform;
 

--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -87,11 +87,10 @@ const TabContent = React.createClass({
       }
     }
     return (
-      <div
-        className={classes}
-        style={style}
-      >
-        {this.getTabPanes()}
+      <div className={`${prefixCls}-content-wrapper`} style={style}>
+        <div className={classes}>
+          {this.getTabPanes()}
+        </div>
       </div>
     );
   },


### PR DESCRIPTION
IE9 无法使用 flex，所以加个 wrapper 以便用 `position: absolute` `float: left` 之类实现类似布局。