### PR TITLE
Child of <Tab> can be null

### DIFF
--- a/src/TabBarMixin.js
+++ b/src/TabBarMixin.js
@@ -22,6 +22,7 @@ export default {
     const prefixCls = props.prefixCls;
 
     React.Children.forEach(children, (child) => {
+      if (!child) return;
       const key = child.key;
       let cls = activeKey === key ? `${prefixCls}-tab-active` : '';
       cls += ` ${prefixCls}-tab`;

--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -27,6 +27,7 @@ const TabContent = React.createClass({
     const newChildren = [];
 
     React.Children.forEach(children, (child) => {
+      if (!child) return;
       const key = child.key;
       const active = activeKey === key;
       newChildren.push(React.cloneElement(child, {


### PR DESCRIPTION
Hello!
I have some use cases, when children of <Tabs> may be null.
For example:
`{ this.state.haveAccessForTab ? <TabPane></TabPane> : null`
Does my changes break anything?
I would be very grateful if these changes go to the upstream.