### PR TITLE
package.json: don't use wildcard in "files"

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "files": [
     "lib",
     "es",
-    "assets/*.css"
+    "assets/index.css"
   ],
   "main": "./lib/index",
   "module": "./es/index",


### PR DESCRIPTION
This works around https://github.com/yarnpkg/yarn/issues/4093