### PR TITLE
Active first tab when children is changed

### DIFF
--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -17,6 +17,11 @@ function getDefaultActiveKey(props) {
   return activeKey;
 }
 
+function activeKeyIsValid(props, key) {
+  const keys = React.Children.map(props.children, child => child.key);
+  return keys.indexOf(key) >= 0;
+}
+
 export default class Tabs extends React.Component {
   constructor(props) {
     super(props);
@@ -39,6 +44,11 @@ export default class Tabs extends React.Component {
     if ('activeKey' in nextProps) {
       this.setState({
         activeKey: nextProps.activeKey,
+      });
+    } else if (!activeKeyIsValid(nextProps, this.state.activeKey)) {
+      // https://github.com/ant-design/ant-design/issues/7093
+      this.setState({
+        activeKey: getDefaultActiveKey(nextProps),
       });
     }
   }

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 import React, { Component } from 'react';
-import { mount, render } from 'enzyme';
+import { mount, shallow, render } from 'enzyme';
 import { renderToJson } from 'enzyme-to-json';
 import Tabs, { TabPane } from '../index';
 import TabContent from '../src/TabContent';
@@ -97,5 +97,46 @@ describe('rc-tabs', () => {
 
     wrapper.find('.rc-tabs-tab-prev').simulate('click');
     expect(onPrevClick).toHaveBeenCalled();
+  });
+
+  it('active first tab when children is changed', () => {
+    const children = [1, 2, 3]
+      .map(number => <TabPane tab={number} key={number.toString()}>{number}</TabPane>);
+    const wrapper = shallow(
+      <Tabs
+        renderTabBar={() => <ScrollableInkTabBar />}
+        renderTabContent={() => <TabContent/>}
+      >
+        {children}
+      </Tabs>
+    );
+    expect(wrapper.state().activeKey).toBe('1');
+    const newChildren = [...children];
+    newChildren.shift();
+    wrapper.setProps({
+      children: newChildren,
+    });
+    expect(wrapper.state().activeKey).toBe('2');
+  });
+
+  it('active first tab when children is not changed at controlled mode', () => {
+    const children = [1, 2, 3]
+      .map(number => <TabPane tab={number} key={number.toString()}>{number}</TabPane>);
+    const wrapper = shallow(
+      <Tabs
+        activeKey="1"
+        renderTabBar={() => <ScrollableInkTabBar />}
+        renderTabContent={() => <TabContent/>}
+      >
+        {children}
+      </Tabs>
+    );
+    expect(wrapper.state().activeKey).toBe('1');
+    const newChildren = [...children];
+    newChildren.shift();
+    wrapper.setProps({
+      children: newChildren,
+    });
+    expect(wrapper.state().activeKey).toBe('1');
   });
 });


### PR DESCRIPTION
close ant-design/ant-design#7093