### PR TITLE
fixed: If the defaultActiveKey is invalid, then set activeKey to another one

### DIFF
--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -23,6 +23,16 @@ function activeKeyIsValid(props, key) {
   return keys.indexOf(key) >= 0;
 }
 
+function defaultActiveKeyIsValid(props, defaultActiveKey) {
+  let idx;
+  React.Children.forEach(props.children, (child, index) => {
+    if (child && !child.props.disabled && child.defaultActiveKey === defaultActiveKey) {
+      idx = index;
+    }
+  });
+  return idx > -1;
+}
+
 export default class Tabs extends React.Component {
   constructor(props) {
     super(props);
@@ -30,7 +40,8 @@ export default class Tabs extends React.Component {
     let activeKey;
     if ('activeKey' in props) {
       activeKey = props.activeKey;
-    } else if ('defaultActiveKey' in props) {
+    } else if ('defaultActiveKey' in props &&
+      defaultActiveKeyIsValid(props, props.defaultActiveKey)) {
       activeKey = props.defaultActiveKey;
     } else {
       activeKey = getDefaultActiveKey(props);


### PR DESCRIPTION
When I set defaultActiveKey to "1", and the pane "1" is disabled, the tab bar shows  pane "1" unexpectedly, but the tag of pane "1" is unclickable. Now if I click another tag, for example "2", then I can't back to pane "1". Take a look at the screen shot.
![qq20170828-163724](https://user-images.githubusercontent.com/13973117/29765876-6aa7e0a6-8c0f-11e7-8299-e592a3b75495.gif)
