### PR TITLE
Fix active bar render bug

### DIFF
--- a/src/InkTabBarMixin.js
+++ b/src/InkTabBarMixin.js
@@ -38,6 +38,12 @@ function offset(elem) {
 }
 
 function componentDidUpdate(component, init) {
+  // If there is no css rendered, don't generate the ink bar
+  // fix https://github.com/ant-design/ant-design/issues/8001
+  if (document.styleSheets.length === 0 ||
+      (document.styleSheets.length === 1 && document.styleSheets[0].rules.length === 0)) {
+    return;
+  }
   const { styles } = component.props;
   const wrapNode = component.nav || component.root;
   const containerOffset = offset(wrapNode);

--- a/src/InkTabBarMixin.js
+++ b/src/InkTabBarMixin.js
@@ -98,7 +98,6 @@ function componentDidUpdate(component, init) {
 }
 
 export default {
-
   getDefaultProps() {
     return {
       inkBarAnimated: true,


### PR DESCRIPTION
 Fix tab active ink bar is rendered too long, when initialize, usually happend with css-loader

close ant-design/ant-design#7564
close ant-design/ant-design#8000
close ant-design/ant-design#8001
close ant-tool/atool-doc#40
close dvajs/dva#1300