### PR TITLE
update new lifecycle methods

### DIFF
--- a/examples/antd.js
+++ b/examples/antd.js
@@ -2,6 +2,7 @@
 import 'rc-tabs/assets/index.less';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { polyfill } from 'react-lifecycles-compat';
 import Tabs, { TabPane } from 'rc-tabs';
 import TabContent from 'rc-tabs/lib/TabContent';
 import ScrollableInkTabBar from 'rc-tabs/lib/ScrollableInkTabBar';
@@ -10,11 +11,13 @@ import InkTabBar from 'rc-tabs/lib/InkTabBar';
 class PanelContent extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {};
     console.log(this.props.id, 'constructor');
   }
 
-  componentWillReceiveProps(nextProps) {
-    console.log(nextProps.id, 'componentWillReceiveProps');
+  static getDerivedStateFromProps(nextProps) {
+    console.log(nextProps.id, 'getDerivedStateFromProps');
+    return null;
   }
 
   render() {
@@ -30,6 +33,8 @@ class PanelContent extends React.Component {
     return <div>{els}</div>;
   }
 }
+
+polyfill(PanelContent);
 
 function construct(start, num) {
   const ends = [];

--- a/examples/defaultActiveKey.js
+++ b/examples/defaultActiveKey.js
@@ -2,6 +2,7 @@
 import 'rc-tabs/assets/index.less';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { polyfill } from 'react-lifecycles-compat';
 import Tabs, { TabPane } from 'rc-tabs';
 import TabContent from 'rc-tabs/lib/TabContent';
 import ScrollableInkTabBar from 'rc-tabs/lib/ScrollableInkTabBar';
@@ -9,11 +10,13 @@ import ScrollableInkTabBar from 'rc-tabs/lib/ScrollableInkTabBar';
 class PanelContent extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {};
     console.log(this.props.id, 'constructor');
   }
 
-  componentWillReceiveProps() {
-    console.log(this.props.id, 'componentWillReceiveProps');
+  static getDerivedStateFromProps(nextProps) {
+    console.log(nextProps.id, 'getDerivedStateFromProps');
+    return null;
   }
 
   render() {
@@ -26,6 +29,8 @@ class PanelContent extends React.Component {
     return <div style={{ height: 200, overflow: 'auto' }}>{els}</div>;
   }
 }
+
+polyfill(PanelContent);
 
 const defaultTabKey = '2';
 

--- a/examples/destroyInactiveTabpanel.js
+++ b/examples/destroyInactiveTabpanel.js
@@ -2,6 +2,7 @@
 import 'rc-tabs/assets/index.less';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { polyfill } from 'react-lifecycles-compat';
 import Tabs, { TabPane } from 'rc-tabs';
 import TabContent from 'rc-tabs/lib/TabContent';
 import ScrollableInkTabBar from 'rc-tabs/lib/ScrollableInkTabBar';
@@ -9,11 +10,13 @@ import ScrollableInkTabBar from 'rc-tabs/lib/ScrollableInkTabBar';
 class PanelContent extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {};
     console.log(this.props.id, 'constructor');
   }
 
-  componentWillReceiveProps() {
-    console.log(this.props.id, 'componentWillReceiveProps');
+  static getDerivedStateFromProps(nextProps) {
+    console.log(nextProps.id, 'getDerivedStateFromProps');
+    return null;
   }
 
   render() {
@@ -24,6 +27,8 @@ class PanelContent extends React.Component {
     return <div>{els}</div>;
   }
 }
+
+polyfill(PanelContent);
 
 class Demo extends React.Component {
   state = {

--- a/examples/router.js
+++ b/examples/router.js
@@ -11,7 +11,8 @@ const Tab1 = () => <div>tab1</div>;
 const Tab2 = () => <div>tab2</div>;
 
 class App extends React.Component {
-  componentWillMount() {
+  constructor() {
+    super();
     this.data = [{
       key: 'tab1',
       component: <Tab1 />,

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "prop-types": "15.x",
     "rc-hammerjs": "~0.6.0",
     "rc-util": "^4.0.4",
+    "react-lifecycles-compat": "^3.0.2",
     "warning": "^3.0.0"
   }
 }

--- a/src/SwipeableTabBarMixin.js
+++ b/src/SwipeableTabBarMixin.js
@@ -1,7 +1,7 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import classnames from 'classnames';
 import Hammer from 'rc-hammerjs';
-import ReactDOM from 'react-dom';
 import {
   isVertical,
   getStyle,
@@ -9,13 +9,6 @@ import {
 } from './utils';
 
 export default {
-  getInitialState() {
-    const { hasPrevPage, hasNextPage } = this.checkPaginationByKey(this.props.activeKey);
-    return {
-      hasPrevPage,
-      hasNextPage,
-    };
-  },
   getDefaultProps() {
     return {
       hammerOptions: {},
@@ -64,10 +57,6 @@ export default {
   setSwipePositionByKey(activeKey) {
     const { hasPrevPage, hasNextPage } = this.checkPaginationByKey(activeKey);
     const { totalAvaliableDelta } = this.cache;
-    this.setState({
-      hasPrevPage,
-      hasNextPage,
-    });
     let delta;
     if (!hasPrevPage) {
       // the first page
@@ -101,10 +90,9 @@ export default {
     };
     this.setSwipePositionByKey(activeKey);
   },
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.activeKey && nextProps.activeKey !== this.props.activeKey) {
-      this.setSwipePositionByKey(nextProps.activeKey);
-    }
+  componentDidUpdate() {
+    const { activeKey } = this.props;
+    this.setSwipePositionByKey(activeKey);
   },
   onPan(e) {
     const { vertical, totalAvaliableDelta, totalDelta } = this.cache;
@@ -123,19 +111,10 @@ export default {
 
     this.cache.totalDelta = _nextDelta;
     this.setSwipePosition();
-
-    // calculate pagination display
-    const { hasPrevPage, hasNextPage } = this.checkPaginationByDelta(this.cache.totalDelta);
-    if (hasPrevPage !== this.state.hasPrevPage || hasNextPage !== this.state.hasNextPage) {
-      this.setState({
-        hasPrevPage,
-        hasNextPage,
-      });
-    }
   },
   getSwipeBarNode(tabs) {
     const { prefixCls, hammerOptions, tabBarPosition } = this.props;
-    const { hasPrevPage, hasNextPage } = this.state;
+    const { hasPrevPage, hasNextPage } = this.checkPaginationByKey(this.props.activeKey);
     const navClassName = `${prefixCls}-nav`;
     const navClasses = classnames({
       [navClassName]: true,

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { polyfill } from 'react-lifecycles-compat';
 import KeyCode from './KeyCode';
 import TabPane from './TabPane';
-import classnames from 'classnames';
 import { getDataAttr } from './utils';
 
 function noop() {
@@ -41,19 +42,6 @@ export default class Tabs extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if ('activeKey' in nextProps) {
-      this.setState({
-        activeKey: nextProps.activeKey,
-      });
-    } else if (!activeKeyIsValid(nextProps, this.state.activeKey)) {
-      // https://github.com/ant-design/ant-design/issues/7093
-      this.setState({
-        activeKey: getDefaultActiveKey(nextProps),
-      });
-    }
-  }
-
   onTabClick = (activeKey) => {
     if (this.tabBar.props.onTabClick) {
       this.tabBar.props.onTabClick(activeKey);
@@ -72,6 +60,16 @@ export default class Tabs extends React.Component {
       const previousKey = this.getNextActiveKey(false);
       this.onTabClick(previousKey);
     }
+  }
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if ('activeKey' in nextProps) {
+      return { activeKey: nextProps.activeKey };
+    } else if (!activeKeyIsValid(nextProps, prevState.activeKey)) {
+      // https://github.com/ant-design/ant-design/issues/7093
+      return { activeKey: getDefaultActiveKey(nextProps) };
+    }
+    return null;
   }
 
   setActiveKey = (activeKey) => {
@@ -162,6 +160,8 @@ export default class Tabs extends React.Component {
     );
   }
 }
+
+polyfill(Tabs);
 
 Tabs.propTypes = {
   destroyInactiveTabPane: PropTypes.bool,


### PR DESCRIPTION
May need refactor mixins, it's hard or even not possible to use 'react-lifecycles-compat' there. State `hasPrevPage, hasNextPage` was removed from SwipeableTabBarMixin as I found it seems no need for them. 

Anyway, not familiar with this part and need review.