### PR TITLE
fix onPanStart with arrow function

### DIFF
--- a/src/SwipeableTabContent.js
+++ b/src/SwipeableTabContent.js
@@ -59,7 +59,7 @@ export default class SwipeableTabContent extends React.Component {
     this.rootNode = ReactDOM.findDOMNode(this);
   }
 
-  onPanStart() {
+  onPanStart = () => {
     const { tabBarPosition, children, activeKey, animated } = this.props;
     const startIndex = this.startIndex = getActiveIndex(children, activeKey);
     if (startIndex === -1) {


### PR DESCRIPTION
#124 Fix the issue that can't not get tabBarPosition and other props
(most of demo are dead)