### PR TITLE
Use computed style

### DIFF
--- a/assets/index/common.less
+++ b/assets/index/common.less
@@ -23,7 +23,7 @@
     background-color: #108ee9;
     transform-origin: 0 0;
     &-animated {
-      transition: transform @effect-duration @easing-in-out;
+      transition: transform @effect-duration @easing-in-out, left @effect-duration @easing-in-out;
     }
   }
 

--- a/src/InkTabBarNode.js
+++ b/src/InkTabBarNode.js
@@ -1,48 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { setTransform, isTransformSupported } from './utils';
-
-export function getScroll(w, top) {
-  let ret = w[`page${top ? 'Y' : 'X'}Offset`];
-  const method = `scroll${top ? 'Top' : 'Left'}`;
-  if (typeof ret !== 'number') {
-    const d = w.document;
-    // ie6,7,8 standard mode
-    ret = d.documentElement[method];
-    if (typeof ret !== 'number') {
-      // quirks mode
-      ret = d.body[method];
-    }
-  }
-  return ret;
-}
-
-function offset(elem) {
-  let box;
-  let x;
-  let y;
-  const doc = elem.ownerDocument;
-  const body = doc.body;
-  const docElem = doc && doc.documentElement;
-  box = elem.getBoundingClientRect();
-  x = box.left;
-  y = box.top;
-  x -= docElem.clientLeft || body.clientLeft || 0;
-  y -= docElem.clientTop || body.clientTop || 0;
-  const w = doc.defaultView || doc.parentWindow;
-  x += getScroll(w);
-  y += getScroll(w, true);
-  return {
-    left: x, top: y,
-  };
-}
+import { setTransform, isTransformSupported, getLeft, getTop } from './utils';
 
 function componentDidUpdate(component, init) {
   const { styles } = component.props;
   const rootNode = component.props.getRef('root');
   const wrapNode = component.props.getRef('nav') || rootNode;
-  const containerOffset = offset(wrapNode);
   const inkBarNode = component.props.getRef('inkBar');
   const activeTab = component.props.getRef('activeTab');
   const inkBarNodeStyle = inkBarNode.style;
@@ -53,10 +17,9 @@ function componentDidUpdate(component, init) {
   }
   if (activeTab) {
     const tabNode = activeTab;
-    const tabOffset = offset(tabNode);
     const transformSupported = isTransformSupported(inkBarNodeStyle);
     if (tabBarPosition === 'top' || tabBarPosition === 'bottom') {
-      let left = tabOffset.left - containerOffset.left;
+      let left = getLeft(tabNode, wrapNode);
       let width = tabNode.offsetWidth;
 
       // If tabNode'width width equal to wrapNode'width when tabBarPosition is top or bottom
@@ -70,6 +33,7 @@ function componentDidUpdate(component, init) {
           left = left + (tabNode.offsetWidth - width) / 2;
         }
       }
+
       // use 3d gpu to optimize render
       if (transformSupported) {
         setTransform(inkBarNodeStyle, `translate3d(${left}px,0,0)`);
@@ -82,7 +46,7 @@ function componentDidUpdate(component, init) {
         inkBarNodeStyle.right = `${wrapNode.offsetWidth - left - width}px`;
       }
     } else {
-      let top = tabOffset.top - containerOffset.top;
+      let top = getTop(tabNode, wrapNode);
       let height = tabNode.offsetHeight;
       if (styles.inkBar && styles.inkBar.height !== undefined) {
         height = parseFloat(styles.inkBar.height, 10);

--- a/src/utils.js
+++ b/src/utils.js
@@ -116,5 +116,7 @@ export function getLeft(tabNode, wrapperNode) {
 }
 
 export function getTop(tabNode, wrapperNode) {
-  return getTypeValue('top', 'height', 'bottom', tabNode, wrapperNode);
+  const top = getTypeValue('top', 'height', 'bottom', tabNode, wrapperNode);
+  const height = getStyle(tabNode.parentNode, 'height');
+  return top - height;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -84,3 +84,37 @@ export function getDataAttr(props) {
     return prev;
   }, {});
 }
+
+function toNum(style, property) {
+  return +style.getPropertyValue(property).replace('px', '');
+}
+
+function getTypeValue(start, current, end, tabNode, wrapperNode) {
+  let total = getStyle(wrapperNode, `padding-${start}`);
+  const { childNodes } = tabNode.parentNode;
+  Array.prototype.some.call(childNodes, (node) => {
+    if (node !== tabNode) {
+      const style = getComputedStyle(node);
+      total += toNum(style, `margin-${start}`);
+      total += toNum(style, `margin-${end}`);
+      total += toNum(style, current);
+
+      if (style.boxSizing === 'content-box') {
+        total += toNum(style, `border-${start}-width`) + toNum(style, `padding-${start}`) +
+          toNum(style, `border-${end}-width`) + toNum(style, `padding-${end}`);
+      }
+      return false;
+    }
+    return true;
+  });
+
+  return total;
+}
+
+export function getLeft(tabNode, wrapperNode) {
+  return getTypeValue('left', 'width', 'right', tabNode, wrapperNode);
+}
+
+export function getTop(tabNode, wrapperNode) {
+  return getTypeValue('top', 'height', 'bottom', tabNode, wrapperNode);
+}


### PR DESCRIPTION
简单来说就是上层 dom 存在 `scale(x)` 的时候，内部通过 `getBoundingClientRect` 计算出的 `left` 值不正确。所以用 `getComputedStyle` 自己算了 left / top

![kapture 2018-09-12 at 15 48 23](https://user-images.githubusercontent.com/5378891/45410253-d6889580-b6a3-11e8-819f-69ea9abc9881.gif)

ref: https://github.com/ant-design/ant-design/issues/8992