### PR TITLE
Adds react to the peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "sortablejs": "^1.7.0"
   },
   "peerDependencies": {
-    "react": "^0.14.3 || ^15.0.0 || ^16.0.0"
+    "react": ">=15"
   },
   "pre-commit": [
     "lint"

--- a/package.json
+++ b/package.json
@@ -89,6 +89,9 @@
     "react-test-renderer": "^16.0.0",
     "sortablejs": "^1.7.0"
   },
+  "peerDependencies": {
+    "react": "^0.14.3 || ^15.0.0 || ^16.0.0"
+  },
   "pre-commit": [
     "lint"
   ],

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "sortablejs": "^1.7.0"
   },
   "peerDependencies": {
-    "react": ">=15"
+    "react": ">=15.0.0"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
The `rc-hammerjs` package has peer dependencies on `react`, which means that `tabs` also depends on it.

Related: https://github.com/react-component/editor-mention/pull/35
Related: https://github.com/react-component/editor-core/pull/35