### PR TITLE
use ResizeObserver to detect size change

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "raf": "^3.4.1",
     "rc-hammerjs": "~0.6.0",
     "rc-util": "^4.0.4",
+    "resize-observer-polyfill": "^1.5.1",
     "warning": "^3.0.0"
   }
 }

--- a/src/ScrollableTabBarNode.js
+++ b/src/ScrollableTabBarNode.js
@@ -22,7 +22,13 @@ export default class ScrollableTabBarNode extends React.Component {
       this.setNextPrev();
       this.scrollToActiveTab();
     }, 200);
-    this.resizeEvent = addEventListener(window, 'resize', this.debouncedResize);
+    if ('ResizeObserver' in window) {
+      this.resizeObserver = new window.ResizeObserver(this.debouncedResize);
+      this.resizeObserver.observe(this.props.getRef('container'));
+    } else {
+      // fallback to window resize event when ResizeObserver is not available
+      this.resizeEvent = addEventListener(window, 'resize', this.debouncedResize);
+    }
   }
 
   componentDidUpdate(prevProps) {
@@ -43,7 +49,9 @@ export default class ScrollableTabBarNode extends React.Component {
   }
 
   componentWillUnmount() {
-    if (this.resizeEvent) {
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+    } else if (this.resizeEvent) {
       this.resizeEvent.remove();
     }
     if (this.debouncedResize && this.debouncedResize.cancel) {

--- a/src/ScrollableTabBarNode.js
+++ b/src/ScrollableTabBarNode.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import addEventListener from 'rc-util/lib/Dom/addEventListener';
 import debounce from 'lodash/debounce';
+import ResizeObserver from 'resize-observer-polyfill';
 import { setTransform, isTransform3dSupported } from './utils';
 
 export default class ScrollableTabBarNode extends React.Component {
@@ -22,13 +22,8 @@ export default class ScrollableTabBarNode extends React.Component {
       this.setNextPrev();
       this.scrollToActiveTab();
     }, 200);
-    if ('ResizeObserver' in window) {
-      this.resizeObserver = new window.ResizeObserver(this.debouncedResize);
-      this.resizeObserver.observe(this.props.getRef('container'));
-    } else {
-      // fallback to window resize event when ResizeObserver is not available
-      this.resizeEvent = addEventListener(window, 'resize', this.debouncedResize);
-    }
+    this.resizeObserver = new ResizeObserver(this.debouncedResize);
+    this.resizeObserver.observe(this.props.getRef('container'));
   }
 
   componentDidUpdate(prevProps) {
@@ -51,8 +46,6 @@ export default class ScrollableTabBarNode extends React.Component {
   componentWillUnmount() {
     if (this.resizeObserver) {
       this.resizeObserver.disconnect();
-    } else if (this.resizeEvent) {
-      this.resizeEvent.remove();
     }
     if (this.debouncedResize && this.debouncedResize.cancel) {
       this.debouncedResize.cancel();

--- a/src/ScrollableTabBarNode.js
+++ b/src/ScrollableTabBarNode.js
@@ -323,7 +323,6 @@ ScrollableTabBarNode.propTypes = {
   children: PropTypes.node,
   prevIcon: PropTypes.node,
   nextIcon: PropTypes.node,
-  activeKey: PropTypes.string,
 };
 
 ScrollableTabBarNode.defaultProps = {


### PR DESCRIPTION
This change uses ResizeObserver to detect size change when it's supported, otherwise fallback to the original method of window resize event.

This should fix https://github.com/ant-design/ant-design/issues/15607 for chrome

Implementing a real resize listener for old browser is just too heavy. I think using ResizeObserver to fix chrome first and wait for other browser to adopt this feature is the best option.