### PR TITLE
Support keyboard

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
     'prefer-destructuring': 0,
     'react/no-unused-prop-types': 0,
     'max-len': 0,
-    'brace-style': 0,
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": true, "optionalDependencies": false, "peerDependencies": false}],
+    'brace-style': 0
   },
 };

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 # History
 ----
 
+## 10.1.0 / 2020-03-17
+
+* Add `keyboard` prop.
+* `extraContent` don't trigger keyboard navigate now.
+* Remove `prop-types` and clean up dependencies.
+
 ## 9.6.0 / 2019-01-16
 
 * ScrollableInkTabBar support render props to customize TabNode

--- a/README.md
+++ b/README.md
@@ -241,6 +241,12 @@ navWrapper={(content) => <Sortable>{content}</Sortable>}
         <th></th>
         <td>the gap between tabs</td>
       </tr>
+      <tr>
+        <td>keyboard</td>
+        <td>boolean</td>
+        <th>true</th>
+        <td>whether support keyboard to navigate tabs</td>
+      </tr>
     </tbody>
 </table>
 

--- a/package.json
+++ b/package.json
@@ -41,12 +41,15 @@
     "prepublishOnly": "npm run lint && npm run test && npm run compile && np --no-cleanup --yolo --no-publish"
   },
   "devDependencies": {
+    "@umijs/fabric": "^2.0.4",
     "coveralls": "^3.0.6",
     "cross-env": "^7.0.2",
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",
     "enzyme-to-json": "^3.3.4",
+    "eslint": "^6.8.0",
     "fastclick": "~1.0.6",
+    "father": "^2.29.2",
     "history": "^1.17.0",
     "immutability-helper": "^3.0.1",
     "less-loader": "^5.0.0",
@@ -54,14 +57,12 @@
     "preact": "^8.2.1",
     "preact-compat": "^3.16.0",
     "react": "^16.0.0",
-    "react-dom": "^16.0.0",
     "react-dnd": "^7.0.2",
     "react-dnd-html5-backend": "^7.0.2",
+    "react-dom": "^16.0.0",
     "react-router": "^3.0.0",
     "react-test-renderer": "^16.0.0",
-    "sortablejs": "^1.7.0",
-    "father": "^2.29.2",
-    "@umijs/fabric": "^2.0.4"
+    "sortablejs": "^1.7.0"
   },
   "dependencies": {
     "classnames": "2.x",

--- a/package.json
+++ b/package.json
@@ -54,23 +54,23 @@
     "preact": "^8.2.1",
     "preact-compat": "^3.16.0",
     "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-dnd": "^7.0.2",
     "react-dnd-html5-backend": "^7.0.2",
     "react-router": "^3.0.0",
     "react-test-renderer": "^16.0.0",
-    "sortablejs": "^1.7.0"
+    "sortablejs": "^1.7.0",
+    "father": "^2.29.2",
+    "@umijs/fabric": "^2.0.4"
   },
   "peerDependencies": {
     "react": ">=15.0.0"
   },
   "dependencies": {
-    "@umijs/fabric": "^2.0.4",
     "classnames": "2.x",
-    "father": "^2.29.2",
     "lodash": "^4.17.5",
     "rc-hammerjs": "~0.6.0",
     "resize-observer-polyfill": "^1.5.1",
-    "warning": "^4.0.3",
-    "react-dom": "^16.0.0"
+    "warning": "^4.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,9 +63,6 @@
     "father": "^2.29.2",
     "@umijs/fabric": "^2.0.4"
   },
-  "peerDependencies": {
-    "react": ">=15.0.0"
-  },
   "dependencies": {
     "classnames": "2.x",
     "lodash": "^4.17.5",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "classnames": "2.x",
     "father": "^2.29.2",
     "lodash": "^4.17.5",
-    "prop-types": "15.x",
     "rc-hammerjs": "~0.6.0",
     "resize-observer-polyfill": "^1.5.1",
     "warning": "^4.0.3",

--- a/src/InkTabBar.js
+++ b/src/InkTabBar.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/prefer-stateless-function */
 import React from 'react';
-import PropTypes from 'prop-types';
 import InkTabBarNode from './InkTabBarNode';
 import TabBarTabsNode from './TabBarTabsNode';
 import TabBarRootNode from './TabBarRootNode';
@@ -20,10 +19,6 @@ export default class InkTabBar extends React.Component {
     );
   }
 }
-
-InkTabBar.propTypes = {
-  onTabClick: PropTypes.func,
-};
 
 InkTabBar.defaultProps = {
   onTabClick: () => {},

--- a/src/InkTabBarNode.js
+++ b/src/InkTabBarNode.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import {
   setTransform,
@@ -120,14 +119,6 @@ export default class InkTabBarNode extends React.Component {
     );
   }
 }
-
-InkTabBarNode.propTypes = {
-  prefixCls: PropTypes.string,
-  styles: PropTypes.object,
-  inkBarAnimated: PropTypes.bool,
-  saveRef: PropTypes.func,
-  direction: PropTypes.string,
-};
 
 InkTabBarNode.defaultProps = {
   prefixCls: '',

--- a/src/SaveRef.js
+++ b/src/SaveRef.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 export default class SaveRef extends React.Component {
   getRef = name => this[name];
@@ -14,10 +13,6 @@ export default class SaveRef extends React.Component {
     return this.props.children(this.saveRef, this.getRef);
   }
 }
-
-SaveRef.propTypes = {
-  children: PropTypes.func,
-};
 
 SaveRef.defaultProps = {
   children: () => null,

--- a/src/ScrollableInkTabBar.js
+++ b/src/ScrollableInkTabBar.js
@@ -1,6 +1,5 @@
 /* eslint-disable react/prefer-stateless-function */
 import React from 'react';
-import PropTypes from 'prop-types';
 import InkTabBarNode from './InkTabBarNode';
 import TabBarTabsNode from './TabBarTabsNode';
 import TabBarRootNode from './TabBarRootNode';
@@ -29,7 +28,3 @@ export default class ScrollableInkTabBar extends React.Component {
     );
   }
 }
-
-ScrollableInkTabBar.propTypes = {
-  children: PropTypes.func,
-};

--- a/src/ScrollableTabBarNode.js
+++ b/src/ScrollableTabBarNode.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import debounce from 'lodash/debounce';
 import ResizeObserver from 'resize-observer-polyfill';
@@ -303,22 +302,6 @@ export default class ScrollableTabBarNode extends React.Component {
     );
   }
 }
-
-ScrollableTabBarNode.propTypes = {
-  activeKey: PropTypes.string,
-  getRef: PropTypes.func.isRequired,
-  saveRef: PropTypes.func.isRequired,
-  tabBarPosition: PropTypes.oneOf(['left', 'right', 'top', 'bottom']),
-  prefixCls: PropTypes.string,
-  scrollAnimated: PropTypes.bool,
-  onPrevClick: PropTypes.func,
-  onNextClick: PropTypes.func,
-  navWrapper: PropTypes.func,
-  children: PropTypes.node,
-  prevIcon: PropTypes.node,
-  nextIcon: PropTypes.node,
-  direction: PropTypes.node,
-};
 
 ScrollableTabBarNode.defaultProps = {
   tabBarPosition: 'left',

--- a/src/SwipeableTabBarNode.js
+++ b/src/SwipeableTabBarNode.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Hammer from 'rc-hammerjs';
 import ReactDOM from 'react-dom';
@@ -205,20 +204,6 @@ export default class SwipeableTabBarNode extends React.Component {
     );
   }
 }
-
-SwipeableTabBarNode.propTypes = {
-  activeKey: PropTypes.string,
-  panels: PropTypes.node,
-  pageSize: PropTypes.number,
-  tabBarPosition: PropTypes.oneOf(['left', 'right', 'top', 'bottom']),
-  prefixCls: PropTypes.string,
-  children: PropTypes.node,
-  hammerOptions: PropTypes.object,
-  speed: PropTypes.number,
-  saveRef: PropTypes.func,
-  getRef: PropTypes.func,
-  direction: PropTypes.string,
-};
 
 SwipeableTabBarNode.defaultProps = {
   panels: null,

--- a/src/SwipeableTabContent.js
+++ b/src/SwipeableTabContent.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import Hammer from 'rc-hammerjs';
 import ReactDOM from 'react-dom';
 import TabContent from './TabContent';
@@ -158,15 +157,6 @@ export default class SwipeableTabContent extends React.Component {
     );
   }
 }
-
-SwipeableTabContent.propTypes = {
-  tabBarPosition: PropTypes.string,
-  onChange: PropTypes.func,
-  children: PropTypes.node,
-  hammerOptions: PropTypes.any,
-  animated: PropTypes.bool,
-  activeKey: PropTypes.string,
-};
 
 SwipeableTabContent.defaultProps = {
   animated: true,

--- a/src/TabBarRootNode.js
+++ b/src/TabBarRootNode.js
@@ -1,5 +1,4 @@
 import React, { cloneElement } from 'react';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { getDataAttr } from './utils';
 
@@ -66,19 +65,6 @@ export default class TabBarRootNode extends React.Component {
     );
   }
 }
-
-TabBarRootNode.propTypes = {
-  prefixCls: PropTypes.string,
-  className: PropTypes.string,
-  style: PropTypes.object,
-  tabBarPosition: PropTypes.oneOf(['left', 'right', 'top', 'bottom']),
-  children: PropTypes.node,
-  extraContent: PropTypes.node,
-  onKeyDown: PropTypes.func,
-  saveRef: PropTypes.func,
-  direction: PropTypes.oneOf(['ltr', 'rtl']),
-  getRef: PropTypes.func,
-};
 
 TabBarRootNode.defaultProps = {
   prefixCls: '',

--- a/src/TabBarRootNode.js
+++ b/src/TabBarRootNode.js
@@ -41,6 +41,7 @@ export default class TabBarRootNode extends React.Component {
       newChildren = [
         cloneElement(extraContent, {
           key: 'extra',
+          onKeyDown: e => e.stopPropagation(),
           style: {
             ...this.getExtraContentStyle(topOrBottom, direction),
             ...extraContentStyle,

--- a/src/TabBarSwipeableTabs.js
+++ b/src/TabBarSwipeableTabs.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 export default class TabBarSwipeableTabs extends React.Component {
@@ -58,17 +57,6 @@ export default class TabBarSwipeableTabs extends React.Component {
     return rst;
   }
 }
-
-TabBarSwipeableTabs.propTypes = {
-  pageSize: PropTypes.number,
-  onTabClick: PropTypes.func,
-  saveRef: PropTypes.func,
-  destroyInactiveTabPane: PropTypes.bool,
-  prefixCls: PropTypes.string,
-  activeKey: PropTypes.string,
-  panels: PropTypes.node,
-  id: PropTypes.string,
-};
 
 TabBarSwipeableTabs.defaultProps = {
   pageSize: 5,

--- a/src/TabBarTabsNode.js
+++ b/src/TabBarTabsNode.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import warning from 'warning';
-import PropTypes from 'prop-types';
 import { isVertical } from './utils';
 
 export default class TabBarTabsNode extends React.Component {
@@ -75,19 +74,6 @@ export default class TabBarTabsNode extends React.Component {
     return <div ref={saveRef('navTabsContainer')}>{rst}</div>;
   }
 }
-
-TabBarTabsNode.propTypes = {
-  activeKey: PropTypes.string,
-  panels: PropTypes.node,
-  prefixCls: PropTypes.string,
-  tabBarGutter: PropTypes.number,
-  onTabClick: PropTypes.func,
-  saveRef: PropTypes.func,
-  renderTabBarNode: PropTypes.func,
-  tabBarPosition: PropTypes.string,
-  direction: PropTypes.string,
-  id: PropTypes.string,
-};
 
 TabBarTabsNode.defaultProps = {
   panels: [],

--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import {
   getTransformByIndex,
@@ -78,20 +77,6 @@ export default class TabContent extends React.Component {
     );
   }
 }
-
-TabContent.propTypes = {
-  animated: PropTypes.bool,
-  animatedWithMargin: PropTypes.bool,
-  prefixCls: PropTypes.string,
-  children: PropTypes.node,
-  activeKey: PropTypes.string,
-  style: PropTypes.any,
-  tabBarPosition: PropTypes.string,
-  className: PropTypes.string,
-  destroyInactiveTabPane: PropTypes.bool,
-  direction: PropTypes.string,
-  id: PropTypes.string,
-};
 
 TabContent.defaultProps = {
   animated: true,

--- a/src/TabPane.js
+++ b/src/TabPane.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { getDataAttr } from './utils';
 
@@ -47,19 +46,6 @@ export default class TabPane extends React.Component {
     );
   }
 }
-
-TabPane.propTypes = {
-  className: PropTypes.string,
-  active: PropTypes.bool,
-  style: PropTypes.any,
-  destroyInactiveTabPane: PropTypes.bool,
-  forceRender: PropTypes.bool,
-  placeholder: PropTypes.node,
-  rootPrefixCls: PropTypes.string,
-  children: PropTypes.node,
-  id: PropTypes.string,
-  tabKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-};
 
 TabPane.defaultProps = {
   placeholder: null,

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import KeyCode from './KeyCode';
 import TabPane from './TabPane';
@@ -192,23 +191,6 @@ class Tabs extends React.Component {
     );
   }
 }
-
-Tabs.propTypes = {
-  destroyInactiveTabPane: PropTypes.bool,
-  renderTabBar: PropTypes.func.isRequired,
-  renderTabContent: PropTypes.func.isRequired,
-  navWrapper: PropTypes.func,
-  onChange: PropTypes.func,
-  children: PropTypes.node,
-  prefixCls: PropTypes.string,
-  className: PropTypes.string,
-  tabBarPosition: PropTypes.string,
-  style: PropTypes.object,
-  activeKey: PropTypes.string,
-  defaultActiveKey: PropTypes.string,
-  direction: PropTypes.string,
-  id: PropTypes.string,
-};
 
 Tabs.defaultProps = {
   prefixCls: 'rc-tabs',

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -65,6 +65,10 @@ class Tabs extends React.Component {
   };
 
   onNavKeyDown = e => {
+    const { keyboard } = this.props;
+    if (!keyboard) {
+      return;
+    }
     const eventKeyCode = e.keyCode;
     if (eventKeyCode === KeyCode.RIGHT || eventKeyCode === KeyCode.DOWN) {
       e.preventDefault();
@@ -210,6 +214,7 @@ Tabs.defaultProps = {
   prefixCls: 'rc-tabs',
   destroyInactiveTabPane: false,
   onChange: noop,
+  keyboard: true,
   navWrapper: arg => arg,
   tabBarPosition: 'top',
   children: null,

--- a/tests/__snapshots__/a11y.spec.js.snap
+++ b/tests/__snapshots__/a11y.spec.js.snap
@@ -12,6 +12,10 @@ exports[`<TabsComponent /> should render correctly 1`] = `
       role="tablist"
       tabindex="-1"
     >
+      <input
+        id="input"
+        style="float:right"
+      />
       <div
         class="rc-tabs-nav-container"
       >
@@ -172,6 +176,10 @@ exports[`<TabsComponent withTabKey /> should render correctly 1`] = `
       role="tablist"
       tabindex="-1"
     >
+      <input
+        id="input"
+        style="float:right"
+      />
       <div
         class="rc-tabs-nav-container"
       >
@@ -343,6 +351,10 @@ exports[`<TabsComponent withTabKey withCustomId /> should render correctly 1`] =
       role="tablist"
       tabindex="-1"
     >
+      <input
+        id="input"
+        style="float:right"
+      />
       <div
         class="rc-tabs-nav-container"
       >

--- a/tests/a11y.spec.js
+++ b/tests/a11y.spec.js
@@ -2,7 +2,6 @@ import React from 'react';
 import TestUtils from 'react-dom/test-utils';
 import { mount, render } from 'enzyme';
 import { renderToJson } from 'enzyme-to-json';
-import PropTypes from 'prop-types';
 import KeyCode from '../src/KeyCode';
 import Tabs, { TabPane } from '../src';
 import TabContent from '../src/TabContent';
@@ -38,11 +37,6 @@ const TabsComponent = ({ withCustomId, withTabKey }) => (
     </Tabs>
   </div>
 );
-
-TabsComponent.propTypes = {
-  withCustomId: PropTypes.bool,
-  withTabKey: PropTypes.bool,
-};
 
 TabsComponent.defaults = {
   withCustomId: false,

--- a/tests/a11y.spec.js
+++ b/tests/a11y.spec.js
@@ -29,7 +29,7 @@ const makeMultiTabPane = (count, withTabKey) => {
 const TabsComponent = ({ withCustomId, withTabKey }) => (
   <div style={{ width: 500, height: 500 }}>
     <Tabs
-      renderTabBar={() => <ScrollableInkTabBar />}
+      renderTabBar={() => <ScrollableInkTabBar extraContent={<input id="input" />} />}
       renderTabContent={() => <TabContent />}
       id={withCustomId && customId}
     >
@@ -76,6 +76,15 @@ describe('<TabsComponent />', () => {
     const thirdTab = tabs.at(2);
     thirdTab.simulate('click');
     expect(document.activeElement).toBe(thirdTab.getDOMNode());
+  });
+
+  fit('xxxx', () => {
+    wrapper.find('#input').simulate('keyDown', {
+      keyCode: KeyCode.RIGHT,
+      which: KeyCode.RIGHT,
+    });
+    expect(tabs.at(0).getDOMNode().className).toContain('rc-tabs-tab-active');
+    expect(tabs.at(1).getDOMNode().className).not.toContain('rc-tabs-tab-active');
   });
 });
 

--- a/tests/a11y.spec.js
+++ b/tests/a11y.spec.js
@@ -60,6 +60,15 @@ describe('<TabsComponent />', () => {
     expect(renderToJson(render(component))).toMatchSnapshot();
   });
 
+  it('extraContent not listen keyboard naviagtion', () => {
+    wrapper.find('#input').simulate('keyDown', {
+      keyCode: KeyCode.RIGHT,
+      which: KeyCode.RIGHT,
+    });
+    expect(tabs.at(0).getDOMNode().className).toContain('rc-tabs-tab-active');
+    expect(tabs.at(1).getDOMNode().className).not.toContain('rc-tabs-tab-active');
+  });
+
   it('first tab should be selected by default', () => {
     const firstTab = tabs.first();
     const selectedTab = tabs.find('[aria-selected="true"]');
@@ -76,15 +85,6 @@ describe('<TabsComponent />', () => {
     const thirdTab = tabs.at(2);
     thirdTab.simulate('click');
     expect(document.activeElement).toBe(thirdTab.getDOMNode());
-  });
-
-  it('extraContent not listen keyboard naviagtion', () => {
-    wrapper.find('#input').simulate('keyDown', {
-      keyCode: KeyCode.RIGHT,
-      which: KeyCode.RIGHT,
-    });
-    expect(tabs.at(0).getDOMNode().className).toContain('rc-tabs-tab-active');
-    expect(tabs.at(1).getDOMNode().className).not.toContain('rc-tabs-tab-active');
   });
 });
 

--- a/tests/a11y.spec.js
+++ b/tests/a11y.spec.js
@@ -78,7 +78,7 @@ describe('<TabsComponent />', () => {
     expect(document.activeElement).toBe(thirdTab.getDOMNode());
   });
 
-  fit('xxxx', () => {
+  it('extraContent not listen keyboard naviagtion', () => {
     wrapper.find('#input').simulate('keyDown', {
       keyCode: KeyCode.RIGHT,
       which: KeyCode.RIGHT,


### PR DESCRIPTION
- [x] 🆕 Add keyboard prop
  - close ant-design/ant-design#22264
- [x] extraContent should not listen to keyborad nav
  - close #242
  - close #254
  - close ant-design/ant-design#9768
  - close ant-design/ant-design#15610
  - close ant-design/ant-design#7948
- [x] Remove `prop-types` and clean up dependencies.