### PR TITLE
⚡️ improve Tabs switch performance

### DIFF
--- a/src/TabPanelList/TabPane.tsx
+++ b/src/TabPanelList/TabPane.tsx
@@ -44,11 +44,12 @@ export default function TabPane({
 
   const mergedStyle: React.CSSProperties = {};
   if (!active) {
-    mergedStyle.visibility = 'hidden';
-
-    if (!animated) {
+    if (animated) {
+      mergedStyle.visibility = 'hidden';
       mergedStyle.height = 0;
       mergedStyle.overflowY = 'hidden';
+    } else {
+      mergedStyle.display = 'none';
     }
   }
 

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -93,7 +93,7 @@ exports[`Tabs.Basic Normal 1`] = `
         class="rc-tabs-tabpane"
         id="rc-tabs-test-panel-light"
         role="tabpanel"
-        style="visibility: hidden; height: 0px; overflow-y: hidden;"
+        style="display: none;"
         tabindex="-1"
       />
       <div
@@ -112,7 +112,7 @@ exports[`Tabs.Basic Normal 1`] = `
         class="rc-tabs-tabpane"
         id="rc-tabs-test-panel-cute"
         role="tabpanel"
-        style="visibility: hidden; height: 0px; overflow-y: hidden;"
+        style="display: none;"
         tabindex="-1"
       />
     </div>


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/25343

When `animated` is false, using `display: none` which is much faster than `visibility: hidden`.

![image](https://user-images.githubusercontent.com/507615/86745789-2d2b4480-c06d-11ea-875e-6d91f3949b9b.png)
