### PR TITLE
Add react and react-dom as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,5 +79,9 @@
     "rc-menu": "^8.6.1",
     "rc-resize-observer": "^0.2.1",
     "rc-util": "^5.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
   }
 }


### PR DESCRIPTION
Fixes errors using Yarn 2 (berry).

See https://github.com/ant-design/ant-design/issues/27339 for details.
