### PR TITLE
fix: scroll position should be reset when all tabs are removed

### DIFF
--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -207,9 +207,13 @@ function TabNavList(props: TabNavListProps, ref: React.Ref<HTMLDivElement>) {
 
   // ========================= Scroll ========================
   function scrollToTab(key = activeKey) {
-    const tabOffset = tabOffsets.get(key);
-
-    if (!tabOffset) return;
+    const tabOffset = tabOffsets.get(key) || {
+      width: 0,
+      height: 0,
+      left: 0,
+      right: 0,
+      top: 0,
+    };
 
     if (tabPositionTopOrBottom) {
       // ============ Align with top & bottom ============

--- a/tests/overflow.test.tsx
+++ b/tests/overflow.test.tsx
@@ -276,6 +276,15 @@ describe('Tabs.Overflow', () => {
       expect(getTransformX(wrapper)).toEqual(-20);
       expect(onTabScroll).toHaveBeenCalledWith({ direction: 'left' });
 
+      // scroll to 0 when activeKey is null
+      onTabScroll.mockReset();
+      wrapper.setProps({ activeKey: null });
+      act(() => {
+        jest.runAllTimers();
+        wrapper.update();
+      });
+      expect(getTransformX(wrapper)).toEqual(0);
+
       jest.useRealTimers();
     });
 


### PR DESCRIPTION
resolves: https://github.com/ant-design/ant-design/issues/27712