### PR TITLE
fix(tabs): disabled animated when tabPosition is left/right

### DIFF
--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -118,7 +118,7 @@ function Tabs(
   const rtl = direction === 'rtl';
 
   let mergedAnimated: AnimatedConfig | false;
-  if (animated === false) {
+  if (animated === false || ['left', 'right'].includes(tabPosition)) {
     mergedAnimated = {
       inkBar: false,
       tabPane: false,


### PR DESCRIPTION
![QQ20220409-223627-HD](https://user-images.githubusercontent.com/39730999/162578792-8ea22519-4b93-484b-bbf9-ca1ddb5b46c6.gif)
![image](https://user-images.githubusercontent.com/39730999/162578848-39a2e5fd-d672-41f1-97c6-93ea92267f39.png)

实际使用中，当`animated`为true的时候，对于`tabPosition`的四个方向都支持动画过渡效果，但是仅支持横向的过渡效果，当`tabPosition`为`left/right`的时候，动画效果应该是纵向过渡的，如果暂时不考虑支持纵向过渡动画，并且要与文档描述相符的话，则当`tabPosition`为`left/right`的时候需要禁用动画效果