### PR TITLE
Fix: TypeError: reactRouter.matchPath is not a function

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-dnd": "^10.0.0",
     "react-dnd-html5-backend": "^10.0.0",
     "react-dom": "^16.0.0",
-    "react-router": "^3.0.0",
+    "react-router": "^5.3.1",
     "react-sticky": "^6.0.3",
     "react-test-renderer": "^16.0.0",
     "sortablejs": "^1.7.0",


### PR DESCRIPTION
Update deps to fix error: TypeError: reactRouter.matchPath is not a function.
![Screenshot](https://user-images.githubusercontent.com/90367928/166219892-dbf9f6ad-8e41-4594-bfbf-38b4bccbca68.png)
