### PR TITLE
feat: add allowScrollCrossTabOnTouchMove props into Tabs Component to improve UX on mobile device

### DIFF
--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -65,6 +65,8 @@ export interface TabsProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'o
   moreIcon?: React.ReactNode;
   /** @private Internal usage. Not promise will rename in future */
   moreTransitionName?: string;
+
+  allowScrollCrossTabOnTouchMove?: boolean;
 }
 
 function parseTabList(children: React.ReactNode): Tab[] {
@@ -110,6 +112,7 @@ function Tabs(
     onChange,
     onTabClick,
     onTabScroll,
+    allowScrollCrossTabOnTouchMove,
     ...restProps
   }: TabsProps,
   ref: React.Ref<HTMLDivElement>,
@@ -215,12 +218,24 @@ function Tabs(
     style: tabBarStyle,
     panes: children,
   };
-
+  
   if (renderTabBar) {
     tabNavBar = renderTabBar(tabNavBarProps, TabNavList);
   } else {
     tabNavBar = <TabNavList {...tabNavBarProps} />;
   }
+  
+  useEffect(() => {
+    if(allowScrollCrossTabOnTouchMove){
+      const rcTabsNav : Element | undefined = document.getElementsByClassName('rc-tabs-nav')[0];
+      if(rcTabsNav){
+        rcTabsNav.addEventListener('touchmove', function(ev){
+          ev.stopPropagation();
+        })
+      }
+    }
+      
+  }, []);
 
   return (
     <TabContext.Provider value={{ tabs, prefixCls }}>


### PR DESCRIPTION
Live Demo: [https://rc-tab-contribution-demo-cyan.vercel.app/demo/allow-scroll-tab-cross-tab-on-touch-move](https://rc-tab-contribution-demo-cyan.vercel.app/demo/allow-scroll-tab-cross-tab-on-touch-move)

**allowScrollCrossTabOnTouchMove = true**

![True-AllowScrollCrossTabOnTouchMove](https://user-images.githubusercontent.com/90367928/166252397-08813ed8-714b-4ad7-aafb-de00bffec5b8.gif)

**allowScrollCrossTabOnTouchMove = false or undefined**

![False-AllowScrollCrossTabOnTouchMove](https://user-images.githubusercontent.com/90367928/166252500-13bc5333-afb3-4719-88d5-74941fe8857b.gif)


