### PR TITLE
fix: Keep the key types and defaultKey types consistent

### DIFF
--- a/src/TabNavList/OperationNode.tsx
+++ b/src/TabNavList/OperationNode.tsx
@@ -15,7 +15,7 @@ export interface OperationNodeProps {
   tabs: Tab[];
   rtl: boolean;
   tabBarGutter?: number;
-  activeKey: string;
+  activeKey: React.Key;
   mobile: boolean;
   moreIcon?: React.ReactNode;
   moreTransitionName?: string;
@@ -49,7 +49,7 @@ function OperationNode(
 ) {
   // ======================== Dropdown ========================
   const [open, setOpen] = useState(false);
-  const [selectedKey, setSelectedKey] = useState<string>(null);
+  const [selectedKey, setSelectedKey] = useState<React.Key>(null);
 
   const popupId = `${id}-more-popup`;
   const dropdownPrefix = `${prefixCls}-dropdown`;
@@ -57,7 +57,7 @@ function OperationNode(
 
   const dropdownAriaLabel = locale?.dropdownAriaLabel;
 
-  function onRemoveTab(event: React.MouseEvent | React.KeyboardEvent, key: string) {
+  function onRemoveTab(event: React.MouseEvent | React.KeyboardEvent, key: React.Key) {
     event.preventDefault();
     event.stopPropagation();
     editable.onEdit('remove', {

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -29,7 +29,7 @@ import useSyncState from '../hooks/useSyncState';
 export interface TabNavListProps {
   id: string;
   tabPosition: TabPosition;
-  activeKey: string;
+  activeKey: React.Key;
   rtl: boolean;
   panes: React.ReactNode;
   animated?: AnimatedConfig;
@@ -43,7 +43,7 @@ export interface TabNavListProps {
   className?: string;
   style?: React.CSSProperties;
   locale?: TabsLocale;
-  onTabClick: (activeKey: string, e: React.MouseEvent | React.KeyboardEvent) => void;
+  onTabClick: (activeKey: React.Key, e: React.MouseEvent | React.KeyboardEvent) => void;
   onTabScroll?: OnTabScroll;
   children?: (node: React.ReactElement) => React.ReactElement;
   popupClassName?: string;

--- a/src/TabPanelList/TabPane.tsx
+++ b/src/TabPanelList/TabPane.tsx
@@ -13,7 +13,7 @@ export interface TabPaneProps {
 
   // Pass by TabPaneList
   prefixCls?: string;
-  tabKey?: string;
+  tabKey?: React.Key;
   id?: string;
   animated?: boolean;
   active?: boolean;

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -42,7 +42,7 @@ export interface TabsProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'o
   id?: string;
 
   activeKey?: string;
-  defaultActiveKey?: string;
+  defaultActiveKey?: React.Key;
   direction?: 'ltr' | 'rtl';
   animated?: boolean | AnimatedConfig;
   renderTabBar?: RenderTabBar;
@@ -147,7 +147,7 @@ function Tabs(
   }, []);
 
   // ====================== Active Key ======================
-  const [mergedActiveKey, setMergedActiveKey] = useMergedState<string>(() => tabs[0]?.key, {
+  const [mergedActiveKey, setMergedActiveKey] = useMergedState<React.Key>(() => tabs[0]?.key, {
     value: activeKey,
     defaultValue: defaultActiveKey,
   });

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import type { TabNavListProps } from './TabNavList';
 import type { TabPaneProps } from './TabPanelList/TabPane';
 
@@ -18,13 +19,13 @@ export type TabOffsetMap = Map<React.Key, TabOffset>;
 export type TabPosition = 'left' | 'right' | 'top' | 'bottom';
 
 export interface Tab extends TabPaneProps {
-  key: string;
+  key: React.Key;
   node: React.ReactElement;
 }
 
 type RenderTabBarProps = {
   id: string;
-  activeKey: string;
+  activeKey: React.Key;
   animated: AnimatedConfig;
   tabPosition: TabPosition;
   rtl: boolean;
@@ -55,7 +56,7 @@ export interface TabsLocale {
 export interface EditableConfig {
   onEdit: (
     type: 'add' | 'remove',
-    info: { key?: string; event: React.MouseEvent | React.KeyboardEvent },
+    info: { key?: React.Key; event: React.MouseEvent | React.KeyboardEvent },
   ) => void;
   showAdd?: boolean;
   removeIcon?: React.ReactNode;


### PR DESCRIPTION
Keep the key types and defaultKey types consistent, for support it, We need changed the key types in react-Component /menu together