### PR TITLE
Fix useComposeRef not found error

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@testing-library/react": "^12.0.0",
     "@types/classnames": "^2.2.10",
     "@types/enzyme": "^3.10.5",
+    "@types/keyv": "3.1.4",
     "@types/jest": "^25.2.3",
     "@types/react": "^17.0.14",
     "@types/react-dom": "^16.9.8",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "rc-menu": "~9.6.0",
     "rc-motion": "^2.6.2",
     "rc-resize-observer": "^1.0.0",
-    "rc-util": "^5.5.0"
+    "rc-util": "^5.16.0"
   },
   "peerDependencies": {
     "react": ">=16.9.0",


### PR DESCRIPTION
[This PR](https://github.com/react-component/tabs/pull/595) introduced the usage of `useComposeRef` (imported from `rc-util`). However, according to the [changelog](https://github.com/react-component/util/releases/tag/v5.16.0), this function was only introduced in 5.16.0. `rc-tabs` only requires `rc-util@^5.5.0` which is why this module might not work under certain setups.

For example, I get the following warning in webpack (which results in a run time exception when starting my web app):

```
WARNING in ./node_modules/rc-tabs/es/TabNavList/index.js 425:9-22
export 'useComposeRef' (imported as 'useComposeRef') was not found in 'rc-util/es/ref' (possible exports: composeRef, fillRef, supportRef)

1 WARNING in child compilations (Use 'stats.children: true' resp. '--stats-children' for more details)
webpack 5.74.0 compiled with 2 warnings in 4588 ms
```

Please merge my PR and create a new release of rc-tabs, as this is currently blocking me from upgrading antd to 4.23.6.