### PR TITLE
onWheel is a passive listener

### DIFF
--- a/src/hooks/useTouchMove.ts
+++ b/src/hooks/useTouchMove.ts
@@ -128,7 +128,7 @@ export default function useTouchMove(
 
     // No need to clean up since element removed
     ref.current.addEventListener('touchstart', onProxyTouchStart, { passive: false });
-    ref.current.addEventListener('wheel', onProxyWheel);
+    ref.current.addEventListener('wheel', onProxyWheel, { passive: true });
 
     return () => {
       document.removeEventListener('touchmove', onProxyTouchMove);


### PR DESCRIPTION
onWheel should be a passive listener so it does not significantly slow down scrolling. It also resolves issue #425 such that Chrome does not log a message to the console:

`useTouchMove.js:154 [Violation] Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952
`