### PR TITLE
fix: resize not trigger

### DIFF
--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -349,6 +349,9 @@ function TabNavList(props: TabNavListProps, ref: React.Ref<HTMLDivElement>) {
       tabContentFullSize[0] - newAddSize[0],
       tabContentFullSize[1] - newAddSize[1],
     ]);
+
+    // Update buttons records
+    updateTabSizes();
   });
 
   // ======================== Dropdown =======================


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/39477

https://github.com/react-component/tabs/pull/620/files#diff-375a69ef7e1bc640b62b899390e743d4f0bcaa3e9f95ca2cb8c61bc2a2137627L335

挪到 effect 里的时候，这边漏了。