### PR TITLE
chore: make dumi types can be resolved

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
       ]
     }
   },
-  "include": [".dumi/**/*", ".dumirc.ts", "src/**/*"]
+  "include": [".dumi/**/*", ".dumirc.ts", "**/*.ts", "**/*.tsx"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,11 +16,12 @@
         "src/*"
       ],
       "@@/*": [
-        "src/.umi/*"
+        ".dumi/tmp/*"
       ],
       "rc-tabs": [
         "src/"
       ]
     }
-  }
+  },
+  "include": [".dumi/**/*", ".dumirc.ts", "src/**/*"]
 }


### PR DESCRIPTION
修复 `.dumirc.ts` 里 `defineConfig` 类型缺失的问题