### PR TITLE
fix: alignInRange execute before tabContentSize change

### DIFF
--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -400,7 +400,7 @@ function TabNavList(props: TabNavListProps, ref: React.Ref<HTMLDivElement>) {
   useEffect(() => {
     scrollToTab();
     // eslint-disable-next-line
-  }, [activeKey, stringify(activeTabOffset), stringify(tabOffsets), tabPositionTopOrBottom]);
+  }, [activeKey, stringify(activeTabOffset), stringify(tabOffsets), tabPositionTopOrBottom, tabContentSizeValue]);
 
   // Should recalculate when rtl changed
   useEffect(() => {

--- a/tests/overflow.test.tsx
+++ b/tests/overflow.test.tsx
@@ -427,6 +427,52 @@ describe('Tabs.Overflow', () => {
     });
   });
 
+  describe('editable', () => {
+    it('add tab and setActive immediately', async () => {
+      jest.useFakeTimers();
+
+      const onEdit = jest.fn();
+      const {container, rerender} = render(getTabs({
+        activeKey: '20', editable: { onEdit }, items: Array.from({ length: 20 }).map((_, idx) => {
+          return {
+            key: String(idx + 1),
+            label: String(idx + 1),
+            children: String(idx + 1),
+          };
+        }),
+      }));
+
+      await triggerResize(container);
+      act(() => {
+        jest.runAllTimers();
+      });
+      expect(getTransformX(container)).toEqual(-370);
+
+      fireEvent.click(container.querySelector('.rc-tabs-nav-operations .rc-tabs-nav-add'));
+      expect(onEdit).toHaveBeenCalledWith('add', {
+        key: undefined,
+        event: expect.anything(),
+      });
+      rerender(getTabs({
+        activeKey: '21', editable: { onEdit }, items: Array.from({ length: 21 }).map((_, idx) => {
+          return {
+            key: String(idx + 1),
+            label: String(idx + 1),
+            children: String(idx + 1),
+          };
+        }),
+      }));
+
+      await triggerResize(container);
+      act(() => {
+        jest.runAllTimers();
+      });
+      expect(getTransformX(container)).toEqual(-390);
+
+      jest.useRealTimers();
+    });
+  });
+
   it('should calculate hidden tabs correctly', () => {
     jest.useFakeTimers();
     const onEdit = jest.fn();


### PR DESCRIPTION
When actively adding tabs, if the tabs just exceed the boundary at this time, because transformMin and transformMax are still in the previous state, it will cause a calculation error

https://github.com/ant-design/ant-design/issues/40155