### PR TITLE
fix: Make event listeners passive - useTouchMove.ts

### DIFF
--- a/src/hooks/useTouchMove.ts
+++ b/src/hooks/useTouchMove.ts
@@ -128,7 +128,7 @@ export default function useTouchMove(
 
     // No need to clean up since element removed
     ref.current.addEventListener('touchstart', onProxyTouchStart, { passive: false });
-    ref.current.addEventListener('wheel', onProxyWheel);
+    ref.current.addEventListener('wheel', onProxyWheel, { passive: false });
 
     return () => {
       document.removeEventListener('touchmove', onProxyTouchMove);


### PR DESCRIPTION
[Violation] Added non-passive event listener to a scroll-blocking 'wheel' event. Consider marking event handler as 'passive' to make the page more responsive.