### PR TITLE
feat: change types into React.Key of tabs props

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -22,7 +22,7 @@ export type TabOffsetMap = Map<React.Key, TabOffset>;
 export type TabPosition = 'left' | 'right' | 'top' | 'bottom';
 
 export interface Tab extends Omit<TabPaneProps, 'tab'> {
-  key: string;
+  key: React.Key;
   label: React.ReactNode;
 }
 


### PR DESCRIPTION
IMO, the `key` type will make more sense as React.Key. Since I have not read the codebase throughly, maybe the `key` is string for a reason. If so, feel free to close this PR. 