### PR TITLE
fix: 根据activeKey显示额外内容导致最后一个tab点击失效

### DIFF
--- a/docs/demo/dynamic-extra.md
+++ b/docs/demo/dynamic-extra.md
@@ -1,0 +1,8 @@
+---
+title: dynamic-extra
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/dynamic-extra.tsx"></code>

--- a/docs/examples/dynamic-extra.tsx
+++ b/docs/examples/dynamic-extra.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import Tabs from '../../src';
+import type { TabsProps } from '../../src';
+import '../../assets/index.less';
+
+const items: TabsProps['items'] = [];
+for (let i = 0; i < 50; i += 1) {
+  items.push({
+    key: String(i),
+    label: `Tab ${i}`,
+    children: `Content of ${i}`,
+  });
+}
+export default () => {
+  const [key, setKey] = React.useState('0');
+
+  const extra = React.useMemo(() => {
+    if (key === '0') {
+      return (
+        <div>额外内容</div>
+      )
+    } 
+    return null
+  }, [key])
+
+  return (
+    <div style={{ maxWidth: 550 }}>
+      <Tabs 
+        activeKey={key}
+        onChange={(curKey) => setKey(curKey)}
+        tabBarExtraContent={extra} 
+        defaultActiveKey="8" 
+        moreIcon="..." 
+        items={items} 
+      />
+    </div>
+  );
+};

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -451,16 +451,16 @@ function TabNavList(props: TabNavListProps, ref: React.Ref<HTMLDivElement>) {
       >
         <ExtraContent ref={extraLeftRef} position="left" extra={extra} prefixCls={prefixCls} />
 
-        <div
-          className={classNames(wrapPrefix, {
-            [`${wrapPrefix}-ping-left`]: pingLeft,
-            [`${wrapPrefix}-ping-right`]: pingRight,
-            [`${wrapPrefix}-ping-top`]: pingTop,
-            [`${wrapPrefix}-ping-bottom`]: pingBottom,
-          })}
-          ref={tabsWrapperRef}
-        >
-          <ResizeObserver onResize={onListHolderResize}>
+        <ResizeObserver onResize={onListHolderResize}>
+          <div
+            className={classNames(wrapPrefix, {
+              [`${wrapPrefix}-ping-left`]: pingLeft,
+              [`${wrapPrefix}-ping-right`]: pingRight,
+              [`${wrapPrefix}-ping-top`]: pingTop,
+              [`${wrapPrefix}-ping-bottom`]: pingBottom,
+            })}
+            ref={tabsWrapperRef}
+          >
             <div
               ref={tabListRef}
               className={`${prefixCls}-nav-list`}
@@ -488,8 +488,8 @@ function TabNavList(props: TabNavListProps, ref: React.Ref<HTMLDivElement>) {
                 style={inkStyle}
               />
             </div>
-          </ResizeObserver>
-        </div>
+          </div>
+        </ResizeObserver>
 
         <OperationNode
           {...props}

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -436,6 +436,7 @@ function TabNavList(props: TabNavListProps, ref: React.Ref<HTMLDivElement>) {
             })}
             ref={tabsWrapperRef}
           >
+            <ResizeObserver onResize={onListHolderResize}>
             <div
               ref={tabListRef}
               className={`${prefixCls}-nav-list`}
@@ -463,6 +464,7 @@ function TabNavList(props: TabNavListProps, ref: React.Ref<HTMLDivElement>) {
                 style={indicatorStyle}
               />
             </div>
+            </ResizeObserver>
           </div>
         </ResizeObserver>
 


### PR DESCRIPTION
resolve https://github.com/ant-design/ant-design/issues/44632
resolve https://github.com/ant-design/ant-design/issues/38270

tabBarExtraContent 如果根据 activeKey 显示时，点击 最后一个tab 时失效

https://github.com/react-component/tabs/assets/13554001/06c1dd56-702c-44b1-800f-a74ad44d5e9a

`ant-design`线上`demo`，操作顺序是 **先点击折叠的Tab4,  然后点击Tab5, 继续点击Tab6**
https://codesandbox.io/s/hua-dong-antd-5-4-2-forked-jp2jmf?file=/demo.tsx

或者使用当前库的demo

```tsx
const items: TabsProps['items'] = [];
for (let i = 0; i < 50; i += 1) {
  items.push({
    key: String(i),
    label: `Tab ${i}`,
    children: `Content of ${i}`,
  });
}
export default () => {
  const [key, setKey] = React.useState('0');

  const extra = React.useMemo(() => {
    if (key === '0') {
      return (
        <div>额外内容</div>
      )
    } 
    return null
  }, [key])

  return (
    <div style={{ maxWidth: 550 }}>
      <Tabs 
        activeKey={key}
        onChange={(curKey) => setKey(curKey)}
        tabBarExtraContent={extra} 
        defaultActiveKey="8" 
        moreIcon="..." 
        items={items} 
      />
    </div>
  );
};

```

原因是： 当额外内容显示为空时，`ResizeObserver` 的 `onResize` 没有重新触发。

fix https://github.com/ant-design/ant-design/issues/44632
