### PR TITLE
fix: tabs dropdown collapse

### DIFF
--- a/src/hooks/useVisibleRange.ts
+++ b/src/hooks/useVisibleRange.ts
@@ -53,7 +53,7 @@ export default function useVisibleRange(
       }
     }
 
-    return [startIndex, endIndex];
+    return startIndex >= endIndex ? [0, 0] : [startIndex, endIndex];
   }, [
     tabOffsets,
     visibleTabContentValue,


### PR DESCRIPTION
这种 DOM size 的 test mock 不出来，比较蛋疼。

fix https://github.com/ant-design/ant-design/issues/42556