### PR TITLE
fix: tab flickering with flex parent cotainer

### DIFF
--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -218,6 +218,8 @@ function TabNavList(props: TabNavListProps, ref: React.Ref<HTMLDivElement>) {
     addSizeValue,
     // Operation
     operationSizeValue,
+    // NeedScroll
+    needScroll,
     { ...props, tabs },
   );
 

--- a/src/hooks/useVisibleRange.ts
+++ b/src/hooks/useVisibleRange.ts
@@ -13,6 +13,7 @@ export default function useVisibleRange(
   tabContentSizeValue: number,
   addNodeSizeValue: number,
   operationNodeSizeValue: number,
+  needScroll: boolean,
   { tabs, tabPosition, rtl }: { tabs: Tab[] } & TabNavListProps,
 ): [visibleStart: number, visibleEnd: number] {
   let charUnit: 'width' | 'height';
@@ -36,9 +37,13 @@ export default function useVisibleRange(
 
     const len = tabs.length;
     let endIndex = len;
+    let contentValue = visibleTabContentValue;
+    if (!needScroll) {
+      contentValue += operationNodeSizeValue;
+    }
     for (let i = 0; i < len; i += 1) {
       const offset = tabOffsets.get(tabs[i].key) || DEFAULT_SIZE;
-      if (offset[position] + offset[charUnit] > transformSize + visibleTabContentValue) {
+      if (offset[position] + offset[charUnit] > transformSize + contentValue) {
         endIndex = i - 1;
         break;
       }


### PR DESCRIPTION
Add the value of operation node size to the calculation if tab not scroll.
fix [ant-design/ant-design#44668](https://github.com/ant-design/ant-design/issues/44668)