### PR TITLE
feat: add overflow trigger props

### DIFF
--- a/src/TabNavList/OperationNode.tsx
+++ b/src/TabNavList/OperationNode.tsx
@@ -4,7 +4,7 @@ import Menu, { MenuItem } from 'rc-menu';
 import KeyCode from 'rc-util/lib/KeyCode';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
-import type { EditableConfig, Tab, TabsLocale, more } from '../interface';
+import type { EditableConfig, Tab, TabsLocale, MoreProps } from '../interface';
 import { getRemovable } from '../util';
 import AddButton from './AddButton';
 
@@ -18,7 +18,7 @@ export interface OperationNodeProps {
   tabBarGutter?: number;
   activeKey: string;
   mobile: boolean;
-  more?: more
+  more?: MoreProps
   moreTransitionName?: string;
   editable?: EditableConfig;
   locale?: TabsLocale;
@@ -52,7 +52,7 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
   const [open, setOpen] = useState(false);
   const [selectedKey, setSelectedKey] = useState<string>(null);
 
-  const { moreIcon = 'More', moreTrigger = 'hover' } = moreProp;
+  const { icon: moreIcon = 'More', trigger = 'hover' } = moreProp;
 
   const popupId = `${id}-more-popup`;
   const dropdownPrefix = `${prefixCls}-dropdown`;
@@ -192,7 +192,7 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
     <Dropdown
       prefixCls={dropdownPrefix}
       overlay={menu}
-      trigger={[`${moreTrigger}`]}
+      trigger={[`${trigger}`]}
       visible={tabs.length ? open : false}
       transitionName={moreTransitionName}
       onVisibleChange={setOpen}

--- a/src/TabNavList/OperationNode.tsx
+++ b/src/TabNavList/OperationNode.tsx
@@ -4,7 +4,7 @@ import Menu, { MenuItem } from 'rc-menu';
 import KeyCode from 'rc-util/lib/KeyCode';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
-import type { EditableConfig, Tab, TabsLocale } from '../interface';
+import type { EditableConfig, Tab, TabsLocale, moreTrigger } from '../interface';
 import { getRemovable } from '../util';
 import AddButton from './AddButton';
 
@@ -19,6 +19,7 @@ export interface OperationNodeProps {
   activeKey: string;
   mobile: boolean;
   moreIcon?: React.ReactNode;
+  moreTrigger?: moreTrigger;
   moreTransitionName?: string;
   editable?: EditableConfig;
   locale?: TabsLocale;
@@ -37,6 +38,7 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
     locale,
     mobile,
     moreIcon = 'More',
+    moreTrigger = 'hover',
     moreTransitionName,
     style,
     className,
@@ -190,7 +192,7 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
     <Dropdown
       prefixCls={dropdownPrefix}
       overlay={menu}
-      trigger={['hover']}
+      trigger={[`${moreTrigger}`]}
       visible={tabs.length ? open : false}
       transitionName={moreTransitionName}
       onVisibleChange={setOpen}

--- a/src/TabNavList/OperationNode.tsx
+++ b/src/TabNavList/OperationNode.tsx
@@ -18,7 +18,7 @@ export interface OperationNodeProps {
   tabBarGutter?: number;
   activeKey: string;
   mobile: boolean;
-  more?: MoreProps
+  more?: MoreProps;
   editable?: EditableConfig;
   locale?: TabsLocale;
   removeAriaLabel?: string;

--- a/src/TabNavList/OperationNode.tsx
+++ b/src/TabNavList/OperationNode.tsx
@@ -4,7 +4,7 @@ import Menu, { MenuItem } from 'rc-menu';
 import KeyCode from 'rc-util/lib/KeyCode';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
-import type { EditableConfig, Tab, TabsLocale, moreTrigger } from '../interface';
+import type { EditableConfig, Tab, TabsLocale, more } from '../interface';
 import { getRemovable } from '../util';
 import AddButton from './AddButton';
 
@@ -18,8 +18,7 @@ export interface OperationNodeProps {
   tabBarGutter?: number;
   activeKey: string;
   mobile: boolean;
-  moreIcon?: React.ReactNode;
-  moreTrigger?: moreTrigger;
+  more?: more
   moreTransitionName?: string;
   editable?: EditableConfig;
   locale?: TabsLocale;
@@ -37,8 +36,7 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
     tabs,
     locale,
     mobile,
-    moreIcon = 'More',
-    moreTrigger = 'hover',
+    more: moreProp = {},
     moreTransitionName,
     style,
     className,
@@ -53,6 +51,8 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
   // ======================== Dropdown ========================
   const [open, setOpen] = useState(false);
   const [selectedKey, setSelectedKey] = useState<string>(null);
+
+  const { moreIcon = 'More', moreTrigger = 'hover' } = moreProp;
 
   const popupId = `${id}-more-popup`;
   const dropdownPrefix = `${prefixCls}-dropdown`;

--- a/src/TabNavList/OperationNode.tsx
+++ b/src/TabNavList/OperationNode.tsx
@@ -36,7 +36,7 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
     tabs,
     locale,
     mobile,
-    more: moreProp = {},
+    more: moreProps = {},
     moreTransitionName,
     style,
     className,
@@ -52,7 +52,7 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
   const [open, setOpen] = useState(false);
   const [selectedKey, setSelectedKey] = useState<string>(null);
 
-  const { icon: moreIcon = 'More', trigger = 'hover' } = moreProp;
+  const { icon: moreIcon = 'More', trigger = 'hover' } = moreProps;
 
   const popupId = `${id}-more-popup`;
   const dropdownPrefix = `${prefixCls}-dropdown`;
@@ -192,7 +192,6 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
     <Dropdown
       prefixCls={dropdownPrefix}
       overlay={menu}
-      trigger={[`${trigger}`]}
       visible={tabs.length ? open : false}
       transitionName={moreTransitionName}
       onVisibleChange={setOpen}
@@ -200,6 +199,7 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
       mouseEnterDelay={0.1}
       mouseLeaveDelay={0.1}
       getPopupContainer={getPopupContainer}
+      {...moreProps}
     >
       <button
         type="button"

--- a/src/TabNavList/OperationNode.tsx
+++ b/src/TabNavList/OperationNode.tsx
@@ -50,7 +50,7 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
   const [open, setOpen] = useState(false);
   const [selectedKey, setSelectedKey] = useState<string>(null);
 
-  const { icon: moreIcon = 'More', trigger = 'hover' } = moreProps;
+  const { icon: moreIcon = 'More' } = moreProps;
 
   const popupId = `${id}-more-popup`;
   const dropdownPrefix = `${prefixCls}-dropdown`;

--- a/src/TabNavList/OperationNode.tsx
+++ b/src/TabNavList/OperationNode.tsx
@@ -19,7 +19,6 @@ export interface OperationNodeProps {
   activeKey: string;
   mobile: boolean;
   more?: MoreProps
-  moreTransitionName?: string;
   editable?: EditableConfig;
   locale?: TabsLocale;
   removeAriaLabel?: string;
@@ -37,7 +36,6 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
     locale,
     mobile,
     more: moreProps = {},
-    moreTransitionName,
     style,
     className,
     editable,
@@ -193,7 +191,6 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
       prefixCls={dropdownPrefix}
       overlay={menu}
       visible={tabs.length ? open : false}
-      transitionName={moreTransitionName}
       onVisibleChange={setOpen}
       overlayClassName={classNames(overlayClassName, popupClassName)}
       mouseEnterDelay={0.1}

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -23,7 +23,7 @@ import type {
   TabPosition,
   TabSizeMap,
   TabsLocale,
-  moreTrigger
+  more,
 } from '../interface';
 import { genDataNodeKey, stringify } from '../util';
 import AddButton from './AddButton';
@@ -39,8 +39,7 @@ export interface TabNavListProps {
   animated?: AnimatedConfig;
   extra?: TabBarExtraContent;
   editable?: EditableConfig;
-  moreIcon?: React.ReactNode;
-  moreTrigger?: moreTrigger;
+  more?: more;
   moreTransitionName?: string;
   mobile: boolean;
   tabBarGutter?: number;

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -16,6 +16,7 @@ import useVisibleRange from '../hooks/useVisibleRange';
 import type {
   AnimatedConfig,
   EditableConfig,
+  MoreProps,
   OnTabScroll,
   RenderTabBar,
   SizeInfo,
@@ -23,7 +24,6 @@ import type {
   TabPosition,
   TabSizeMap,
   TabsLocale,
-  more,
 } from '../interface';
 import { genDataNodeKey, stringify } from '../util';
 import AddButton from './AddButton';
@@ -39,7 +39,7 @@ export interface TabNavListProps {
   animated?: AnimatedConfig;
   extra?: TabBarExtraContent;
   editable?: EditableConfig;
-  more?: more;
+  more?: MoreProps;
   moreTransitionName?: string;
   mobile: boolean;
   tabBarGutter?: number;

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -23,6 +23,7 @@ import type {
   TabPosition,
   TabSizeMap,
   TabsLocale,
+  moreTrigger
 } from '../interface';
 import { genDataNodeKey, stringify } from '../util';
 import AddButton from './AddButton';
@@ -39,6 +40,7 @@ export interface TabNavListProps {
   extra?: TabBarExtraContent;
   editable?: EditableConfig;
   moreIcon?: React.ReactNode;
+  moreTrigger?: moreTrigger;
   moreTransitionName?: string;
   mobile: boolean;
   tabBarGutter?: number;

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -40,7 +40,6 @@ export interface TabNavListProps {
   extra?: TabBarExtraContent;
   editable?: EditableConfig;
   more?: MoreProps;
-  moreTransitionName?: string;
   mobile: boolean;
   tabBarGutter?: number;
   renderTabBar?: RenderTabBar;

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -18,6 +18,7 @@ import type {
   TabBarExtraContent,
   TabPosition,
   TabsLocale,
+  moreTrigger,
 } from './interface';
 
 /**
@@ -65,6 +66,7 @@ export interface TabsProps
 
   // Icons
   moreIcon?: React.ReactNode;
+  moreTrigger?: moreTrigger;
   /** @private Internal usage. Not promise will rename in future */
   moreTransitionName?: string;
   popupClassName?: string;
@@ -91,6 +93,7 @@ const Tabs = React.forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
     tabBarExtraContent,
     locale,
     moreIcon,
+    moreTrigger,
     moreTransitionName,
     destroyInactiveTabPane,
     renderTabBar,
@@ -174,6 +177,7 @@ const Tabs = React.forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
     editable,
     locale,
     moreIcon,
+    moreTrigger,
     moreTransitionName,
     tabBarGutter,
     onTabClick: onInternalTabClick,

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -67,7 +67,6 @@ export interface TabsProps
   // Icons
   more?: MoreProps;
   /** @private Internal usage. Not promise will rename in future */
-  moreTransitionName?: string;
   popupClassName?: string;
   indicator?: {
     size?: GetIndicatorSize;
@@ -92,7 +91,6 @@ const Tabs = React.forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
     tabBarExtraContent,
     locale,
     more,
-    moreTransitionName,
     destroyInactiveTabPane,
     renderTabBar,
     onChange,
@@ -175,7 +173,6 @@ const Tabs = React.forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
     editable,
     locale,
     more,
-    moreTransitionName,
     tabBarGutter,
     onTabClick: onInternalTabClick,
     onTabScroll,

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -12,13 +12,13 @@ import type { GetIndicatorSize } from './hooks/useIndicator';
 import type {
   AnimatedConfig,
   EditableConfig,
+  MoreProps,
   OnTabScroll,
   RenderTabBar,
   Tab,
   TabBarExtraContent,
   TabPosition,
   TabsLocale,
-  more,
 } from './interface';
 
 /**
@@ -65,7 +65,7 @@ export interface TabsProps
   locale?: TabsLocale;
 
   // Icons
-  more?: more;
+  more?: MoreProps;
   /** @private Internal usage. Not promise will rename in future */
   moreTransitionName?: string;
   popupClassName?: string;

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -18,7 +18,7 @@ import type {
   TabBarExtraContent,
   TabPosition,
   TabsLocale,
-  moreTrigger,
+  more,
 } from './interface';
 
 /**
@@ -65,8 +65,7 @@ export interface TabsProps
   locale?: TabsLocale;
 
   // Icons
-  moreIcon?: React.ReactNode;
-  moreTrigger?: moreTrigger;
+  more?: more;
   /** @private Internal usage. Not promise will rename in future */
   moreTransitionName?: string;
   popupClassName?: string;
@@ -92,8 +91,7 @@ const Tabs = React.forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
     tabBarStyle,
     tabBarExtraContent,
     locale,
-    moreIcon,
-    moreTrigger,
+    more,
     moreTransitionName,
     destroyInactiveTabPane,
     renderTabBar,
@@ -176,8 +174,7 @@ const Tabs = React.forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
     ...sharedProps,
     editable,
     locale,
-    moreIcon,
-    moreTrigger,
+    more,
     moreTransitionName,
     tabBarGutter,
     onTabClick: onInternalTabClick,

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -10,7 +10,6 @@ export type TriggerProps = {
 export type moreIcon = React.ReactNode;
 export type MoreProps = {
   icon?: moreIcon,
-  transitionName?: string,
 } & Omit<DropdownProps, 'children'>;
 
 export type SizeInfo = [width: number, height: number];

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -3,6 +3,8 @@ import type React from 'react';
 import type { TabNavListProps } from './TabNavList';
 import type { TabPaneProps } from './TabPanelList/TabPane';
 
+export type moreTrigger = 'click' | 'hover';
+
 export type SizeInfo = [width: number, height: number];
 
 export type TabSizeMap = Map<

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -45,8 +45,7 @@ type RenderTabBarProps = {
   mobile: boolean;
   editable: EditableConfig;
   locale: TabsLocale;
-  moreIcon: React.ReactNode;
-  moreTransitionName: string;
+  more: MoreProps,
   tabBarGutter: number;
   onTabClick: (key: string, e: React.MouseEvent | React.KeyboardEvent) => void;
   onTabScroll: OnTabScroll;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -3,12 +3,13 @@ import type React from 'react';
 import type { TabNavListProps } from './TabNavList';
 import type { TabPaneProps } from './TabPanelList/TabPane';
 
-export type moreTrigger = 'click' | 'hover';
-export type moreIcon = React.ReactNode;
-export type more = {
-  moreTrigger?: moreTrigger,
-  moreIcon?: moreIcon,
+export type TriggerProps = {
+  trigger?: 'hover' | 'click';
 }
+export type moreIcon = React.ReactNode;
+export type MoreProps = {
+  icon?: moreIcon,
+} & TriggerProps ;
 
 export type SizeInfo = [width: number, height: number];
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -2,6 +2,7 @@ import type { CSSMotionProps } from 'rc-motion';
 import type React from 'react';
 import type { TabNavListProps } from './TabNavList';
 import type { TabPaneProps } from './TabPanelList/TabPane';
+import { DropdownProps } from 'rc-dropdown/lib/Dropdown';
 
 export type TriggerProps = {
   trigger?: 'hover' | 'click';
@@ -9,7 +10,7 @@ export type TriggerProps = {
 export type moreIcon = React.ReactNode;
 export type MoreProps = {
   icon?: moreIcon,
-} & TriggerProps ;
+} & Omit<DropdownProps, 'children'>;
 
 export type SizeInfo = [width: number, height: number];
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -10,6 +10,7 @@ export type TriggerProps = {
 export type moreIcon = React.ReactNode;
 export type MoreProps = {
   icon?: moreIcon,
+  transitionName?: string,
 } & Omit<DropdownProps, 'children'>;
 
 export type SizeInfo = [width: number, height: number];

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -4,6 +4,11 @@ import type { TabNavListProps } from './TabNavList';
 import type { TabPaneProps } from './TabPanelList/TabPane';
 
 export type moreTrigger = 'click' | 'hover';
+export type moreIcon = React.ReactNode;
+export type more = {
+  moreTrigger?: moreTrigger,
+  moreIcon?: moreIcon,
+}
 
 export type SizeInfo = [width: number, height: number];
 

--- a/tests/overflow.test.tsx
+++ b/tests/overflow.test.tsx
@@ -94,9 +94,8 @@ describe('Tabs.Overflow', () => {
 
   it('should open dropdown on click when moreTrigger is set to click', () => {
     jest.useFakeTimers();
-    const more = { icon: 'xxx', trigger: 'click' };
     const onChange = jest.fn();
-    const { container, unmount } = render(getTabs({ onChange, more: { icon: 'xxx', trigger: 'click' } }));
+    const { container, unmount } = render(getTabs({ onChange, more: {icon: '...', trigger: 'click'} }));
     triggerResize(container);
     act(() => {
       jest.runAllTimers();

--- a/tests/overflow.test.tsx
+++ b/tests/overflow.test.tsx
@@ -95,7 +95,7 @@ describe('Tabs.Overflow', () => {
   it('should open dropdown on click when moreTrigger is set to click', () => {
     jest.useFakeTimers();
     const onChange = jest.fn();
-    const { container, unmount } = render(getTabs({ onChange, moreTrigger: 'click' }));
+    const { container, unmount } = render(getTabs({ onChange, more: { moreTrigger: 'click' } }));
     triggerResize(container);
     act(() => {
       jest.runAllTimers();

--- a/tests/overflow.test.tsx
+++ b/tests/overflow.test.tsx
@@ -94,8 +94,9 @@ describe('Tabs.Overflow', () => {
 
   it('should open dropdown on click when moreTrigger is set to click', () => {
     jest.useFakeTimers();
+    const more = { icon: 'xxx', trigger: 'click' };
     const onChange = jest.fn();
-    const { container, unmount } = render(getTabs({ onChange, more: { moreTrigger: 'click' } }));
+    const { container, unmount } = render(getTabs({ onChange, more: { icon: 'xxx', trigger: 'click' } }));
     triggerResize(container);
     act(() => {
       jest.runAllTimers();

--- a/tests/overflow.test.tsx
+++ b/tests/overflow.test.tsx
@@ -92,6 +92,24 @@ describe('Tabs.Overflow', () => {
     jest.useRealTimers();
   });
 
+  it('should open dropdown on click when moreTrigger is set to click', () => {
+    jest.useFakeTimers();
+    const onChange = jest.fn();
+    const { container, unmount } = render(getTabs({ onChange, moreTrigger: 'click' }));
+    triggerResize(container);
+    act(() => {
+      jest.runAllTimers();
+    });
+    const button = container.querySelector('.rc-tabs-nav-more')
+    fireEvent.click(button);
+    act(() => {
+      jest.runAllTimers();
+    });
+    const dropdownOpen = container.querySelector('.rc-tabs-dropdown-open');
+    expect(dropdownOpen).not.toBeNull();
+    unmount();
+  });
+
   [KeyCode.SPACE, KeyCode.ENTER].forEach(code => {
     it(`keyboard with select keycode: ${code}`, () => {
       jest.useFakeTimers();


### PR DESCRIPTION
ref：https://github.com/ant-design/ant-design/issues/48085
add a new props to control overflow trigger way

In the tabs component, currently we only have hover functionality for triggering the overflow. However, some scenarios require a click action.