### PR TITLE
fix: resolve passive warning

### DIFF
--- a/src/hooks/useTouchMove.ts
+++ b/src/hooks/useTouchMove.ts
@@ -124,11 +124,11 @@ export default function useTouchMove(
     }
 
     document.addEventListener('touchmove', onProxyTouchMove, { passive: false });
-    document.addEventListener('touchend', onProxyTouchEnd, { passive: false });
+    document.addEventListener('touchend', onProxyTouchEnd, { passive: true });
 
     // No need to clean up since element removed
-    ref.current.addEventListener('touchstart', onProxyTouchStart, { passive: false });
-    ref.current.addEventListener('wheel', onProxyWheel);
+    ref.current.addEventListener('touchstart', onProxyTouchStart, { passive: true });
+    ref.current.addEventListener('wheel', onProxyWheel, { passive: false });
 
     return () => {
       document.removeEventListener('touchmove', onProxyTouchMove);


### PR DESCRIPTION
touchstart、touchend 中都没有调用 preventDefault，所以改为 true。
wheel 中有调用 preventDefault，改为 false

![image](https://github.com/react-component/tabs/assets/47104575/727cb6a1-378e-4219-afe5-00d30ec5ba17)
