### PR TITLE
fix: The OperationNode will repeatedly change status between appearing and disappearing.

### DIFF
--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -150,7 +150,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
   const addSizeValue = getUnitValue(addSize, tabPositionTopOrBottom);
   const operationSizeValue = getUnitValue(operationSize, tabPositionTopOrBottom);
 
-  const needScroll = containerExcludeExtraSizeValue < tabContentSizeValue + addSizeValue;
+  const needScroll = Math.floor(containerExcludeExtraSizeValue) < Math.floor(tabContentSizeValue + addSizeValue);
   const visibleTabContentValue = needScroll
     ? containerExcludeExtraSizeValue - operationSizeValue
     : containerExcludeExtraSizeValue - addSizeValue;


### PR DESCRIPTION
In my case,when I use the `Tabs` component of `antd`, I have found the OperationNode will repeatedly change status between appearing and disappearing when the tabs component's with is almost equal to the sum of the width of all tab items.
![20240716164921_rec_](https://github.com/user-attachments/assets/99c34381-9972-47ee-8c5b-a6f204121641)

Then I found one of the parameters `visibleTabContentValue` of hook function `useVisibleRange` will repeatedly change. I just try to figure it out what happen.

At last, I've found that the `needScroll` value's judgemental condition maybe not correct.(the value of `t+a` is `tabContentSizeValue + addSizeValue`). We can find these two number is almost equal so that they are equal. And then the needScroll is false.
![image](https://github.com/user-attachments/assets/7a5eb278-48e7-47bf-b290-7f84b39876d4)

So I think the `needScroll` can be just only comparing the part of integer is enough.
![image](https://github.com/user-attachments/assets/7262ebb5-3252-49cb-8ed8-4b9b90b6eaa6)

BTW, I just only test my case without other complicated use. If there are other problems, welcome to point them out

 
