### PR TITLE
refactor: enhance tab navigation and accessibility features

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -10,32 +10,32 @@
 @effect-duration: 0.3s;
 
 .@{tabs-prefix-cls} {
-  border: 1px solid gray;
-  font-size: 14px;
   overflow: hidden;
+  font-size: 14px;
+  border: 1px solid gray;
 
   // ========================== Navigation ==========================
   &-nav {
+    position: relative;
     display: flex;
     flex: none;
-    position: relative;
 
     &-measure,
     &-wrap {
-      transform: translate(0);
       position: relative;
       display: inline-block;
-      flex: auto;
-      white-space: nowrap;
-      overflow: hidden;
       display: flex;
+      flex: auto;
+      overflow: hidden;
+      white-space: nowrap;
+      transform: translate(0);
 
       &-ping-left::before,
       &-ping-right::after {
-        content: '';
         position: absolute;
         top: 0;
         bottom: 0;
+        content: '';
       }
       &-ping-left::before {
         left: 0;
@@ -48,10 +48,10 @@
 
       &-ping-top::before,
       &-ping-bottom::after {
-        content: '';
         position: absolute;
-        left: 0;
         right: 0;
+        left: 0;
+        content: '';
       }
       &-ping-top::before {
         top: 0;
@@ -64,8 +64,8 @@
     }
 
     &-list {
-      display: flex;
       position: relative;
+      display: flex;
       transition: transform 0.3s;
     }
 
@@ -81,36 +81,39 @@
     }
 
     &-more {
-      border: 1px solid blue;
       background: rgba(255, 0, 0, 0.1);
+      border: 1px solid blue;
     }
     &-add {
-      border: 1px solid green;
       background: rgba(0, 255, 0, 0.1);
+      border: 1px solid green;
     }
   }
 
   &-tab {
-    border: 0;
+    position: relative;
+    display: flex;
+    align-items: center;
+    margin: 0;
+    font-weight: lighter;
     font-size: 20px;
     background: rgba(255, 255, 255, 0.5);
-    margin: 0;
-    display: flex;
+    border: 0;
     outline: none;
     cursor: pointer;
-    position: relative;
-    font-weight: lighter;
-    align-items: center;
 
     &-btn,
     &-remove {
-      border: 0;
       background: transparent;
+      border: 0;
     }
 
     &-btn {
       font-weight: inherit;
       line-height: 32px;
+      &:focus {
+        outline: none;
+      }
     }
 
     &-remove {
@@ -120,8 +123,11 @@
     }
 
     &-active {
-      // padding-left: 30px;
       font-weight: bolder;
+    }
+
+    &-focus {
+      outline: 1px auto #1677ff;
     }
   }
 

--- a/docs/examples/basic.tsx
+++ b/docs/examples/basic.tsx
@@ -24,7 +24,14 @@ export default () => {
       disabled: true,
       icon: <span>🐼</span>,
     },
+    {
+      label: 'Yo',
+      key: 'yo',
+      children: 'Yo!',
+      icon: <span>👋</span>,
+    },
   ]);
+  const [direction, setDirection] = React.useState<'ltr' | 'rtl'>('ltr');
 
   if (destroy) {
     return null;
@@ -32,7 +39,7 @@ export default () => {
 
   return (
     <React.StrictMode>
-      <Tabs tabBarExtraContent="extra" items={items} />
+      <Tabs tabBarExtraContent="extra" direction={direction} items={items} />
       <button
         type="button"
         onClick={() => {
@@ -55,6 +62,14 @@ export default () => {
         }}
       >
         Destroy
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setDirection(direction === 'ltr' ? 'rtl' : 'ltr');
+        }}
+      >
+        {direction}
       </button>
     </React.StrictMode>
   );

--- a/docs/examples/basic.tsx
+++ b/docs/examples/basic.tsx
@@ -37,9 +37,18 @@ export default () => {
     return null;
   }
 
+  const onTabClick = (key: string) => {
+    console.log('key', key);
+  };
+
   return (
     <React.StrictMode>
-      <Tabs tabBarExtraContent="extra" direction={direction} items={items} />
+      <Tabs
+        tabBarExtraContent="extra"
+        onTabClick={onTabClick}
+        direction={direction}
+        items={items}
+      />
       <button
         type="button"
         onClick={() => {

--- a/docs/examples/basic.tsx
+++ b/docs/examples/basic.tsx
@@ -78,7 +78,7 @@ export default () => {
           setDirection(direction === 'ltr' ? 'rtl' : 'ltr');
         }}
       >
-        {direction}
+        {direction === 'ltr' ? 'rtl' : 'ltr'}
       </button>
     </React.StrictMode>
   );

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@rc-component/trigger": "^2.0.0",
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
     "@types/classnames": "^2.2.10",
     "@types/enzyme": "^3.10.5",
     "@types/jest": "^29.4.0",

--- a/src/TabNavList/TabNode.tsx
+++ b/src/TabNavList/TabNode.tsx
@@ -15,6 +15,8 @@ export interface TabNodeProps {
   onResize?: (width: number, height: number, left: number, top: number) => void;
   renderWrapper?: (node: React.ReactElement) => React.ReactElement;
   removeAriaLabel?: string;
+  tabCount: number;
+  currentPosition: number;
   removeIcon?: React.ReactNode;
   onKeyDown: React.KeyboardEventHandler;
   onMouseDown: React.MouseEventHandler;
@@ -42,6 +44,8 @@ const TabNode: React.FC<TabNodeProps> = props => {
     onMouseDown,
     onMouseUp,
     style,
+    tabCount,
+    currentPosition,
   } = props;
   const tabPrefix = `${prefixCls}-tab`;
 
@@ -106,6 +110,22 @@ const TabNode: React.FC<TabNodeProps> = props => {
         onFocus={onFocus}
         onBlur={onBlur}
       >
+        {focus && (
+          <div
+            aria-live="polite"
+            style={{
+              position: 'absolute',
+              width: 1,
+              height: 1,
+              overflow: 'hidden',
+              padding: 0,
+              margin: -1,
+              clip: 'rect(0, 0, 0, 0)',
+            }}
+          >
+            {`Tab ${currentPosition} of ${tabCount}，`}
+          </div>
+        )}
         {icon && <span className={`${tabPrefix}-icon`}>{icon}</span>}
         {label && labelNode}
       </div>

--- a/src/TabNavList/TabNode.tsx
+++ b/src/TabNavList/TabNode.tsx
@@ -106,7 +106,7 @@ const TabNode: React.FC<TabNodeProps> = props => {
         <button
           type="button"
           aria-label={removeAriaLabel || 'remove'}
-          tabIndex={0}
+          tabIndex={-1}
           className={`${tabPrefix}-remove`}
           onClick={e => {
             e.stopPropagation();

--- a/src/TabNavList/TabNode.tsx
+++ b/src/TabNavList/TabNode.tsx
@@ -65,6 +65,7 @@ const TabNode: React.FC<TabNodeProps> = props => {
 
   const node: React.ReactElement = (
     <div
+      role="tab"
       key={key}
       data-node-key={genDataNodeKey(key)}
       className={classNames(tabPrefix, {
@@ -78,7 +79,6 @@ const TabNode: React.FC<TabNodeProps> = props => {
     >
       {/* Primary Tab Button */}
       <div
-        role="tab"
         aria-selected={active}
         id={id && `${id}-tab-${key}`}
         className={`${tabPrefix}-btn`}

--- a/src/TabNavList/TabNode.tsx
+++ b/src/TabNavList/TabNode.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames';
-import KeyCode from 'rc-util/lib/KeyCode';
 import * as React from 'react';
 import type { EditableConfig, Tab } from '../interface';
 import { genDataNodeKey, getRemovable } from '../util';
@@ -64,14 +63,6 @@ const TabNode: React.FC<TabNodeProps> = props => {
     [label, icon],
   );
 
-  function onInternalKeyDown(e: React.KeyboardEvent) {
-    onKeyDown(e);
-    if (e.which === KeyCode.SPACE || e.which === KeyCode.ENTER) {
-      e.preventDefault();
-      onInternalClick(e);
-    }
-  }
-
   const node: React.ReactElement = (
     <div
       key={key}
@@ -98,7 +89,7 @@ const TabNode: React.FC<TabNodeProps> = props => {
           e.stopPropagation();
           onInternalClick(e);
         }}
-        onKeyDown={onInternalKeyDown}
+        onKeyDown={onKeyDown}
         onMouseDown={onMouseDown}
         onFocus={onFocus}
         onBlur={onBlur}

--- a/src/TabNavList/TabNode.tsx
+++ b/src/TabNavList/TabNode.tsx
@@ -115,7 +115,7 @@ const TabNode: React.FC<TabNodeProps> = props => {
         <button
           type="button"
           aria-label={removeAriaLabel || 'remove'}
-          tabIndex={-1}
+          tabIndex={active ? 0 : -1}
           className={`${tabPrefix}-remove`}
           onClick={e => {
             e.stopPropagation();

--- a/src/TabNavList/TabNode.tsx
+++ b/src/TabNavList/TabNode.tsx
@@ -18,6 +18,7 @@ export interface TabNodeProps {
   removeIcon?: React.ReactNode;
   onKeyDown: React.KeyboardEventHandler;
   onMouseDown: React.MouseEventHandler;
+  onMouseUp: React.MouseEventHandler;
   onFocus: React.FocusEventHandler;
   onBlur: React.FocusEventHandler;
   style?: React.CSSProperties;
@@ -39,6 +40,7 @@ const TabNode: React.FC<TabNodeProps> = props => {
     onBlur,
     onKeyDown,
     onMouseDown,
+    onMouseUp,
     style,
   } = props;
   const tabPrefix = `${prefixCls}-tab`;
@@ -91,6 +93,7 @@ const TabNode: React.FC<TabNodeProps> = props => {
         }}
         onKeyDown={onKeyDown}
         onMouseDown={onMouseDown}
+        onMouseUp={onMouseUp}
         onFocus={onFocus}
         onBlur={onBlur}
       >

--- a/src/TabNavList/TabNode.tsx
+++ b/src/TabNavList/TabNode.tsx
@@ -65,6 +65,14 @@ const TabNode: React.FC<TabNodeProps> = props => {
     [label, icon],
   );
 
+  const btnRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (focus && btnRef.current) {
+      btnRef.current.focus();
+    }
+  }, [focus]);
+
   const node: React.ReactElement = (
     <div
       key={key}
@@ -80,6 +88,7 @@ const TabNode: React.FC<TabNodeProps> = props => {
     >
       {/* Primary Tab Button */}
       <div
+        ref={btnRef}
         role="tab"
         aria-selected={active}
         id={id && `${id}-tab-${key}`}

--- a/src/TabNavList/TabNode.tsx
+++ b/src/TabNavList/TabNode.tsx
@@ -113,17 +113,9 @@ const TabNode: React.FC<TabNodeProps> = props => {
         {focus && (
           <div
             aria-live="polite"
-            style={{
-              position: 'absolute',
-              width: 1,
-              height: 1,
-              overflow: 'hidden',
-              padding: 0,
-              margin: -1,
-              clip: 'rect(0, 0, 0, 0)',
-            }}
+            style={{ width: 0, height: 0, position: 'absolute', overflow: 'hidden', opacity: 0 }}
           >
-            {`Tab ${currentPosition} of ${tabCount}，`}
+            {`Tab ${currentPosition} of ${tabCount}`}
           </div>
         )}
         {icon && <span className={`${tabPrefix}-icon`}>{icon}</span>}

--- a/src/TabNavList/TabNode.tsx
+++ b/src/TabNavList/TabNode.tsx
@@ -65,7 +65,6 @@ const TabNode: React.FC<TabNodeProps> = props => {
 
   const node: React.ReactElement = (
     <div
-      role="tab"
       key={key}
       data-node-key={genDataNodeKey(key)}
       className={classNames(tabPrefix, {
@@ -79,6 +78,7 @@ const TabNode: React.FC<TabNodeProps> = props => {
     >
       {/* Primary Tab Button */}
       <div
+        role="tab"
         aria-selected={active}
         id={id && `${id}-tab-${key}`}
         className={`${tabPrefix}-btn`}

--- a/src/TabNavList/TabNode.tsx
+++ b/src/TabNavList/TabNode.tsx
@@ -9,6 +9,7 @@ export interface TabNodeProps {
   prefixCls: string;
   tab: Tab;
   active: boolean;
+  focus: boolean;
   closable?: boolean;
   editable?: EditableConfig;
   onClick?: (e: React.MouseEvent | React.KeyboardEvent) => void;
@@ -16,7 +17,10 @@ export interface TabNodeProps {
   renderWrapper?: (node: React.ReactElement) => React.ReactElement;
   removeAriaLabel?: string;
   removeIcon?: React.ReactNode;
+  onKeyDown: React.KeyboardEventHandler;
+  onMouseDown: React.MouseEventHandler;
   onFocus: React.FocusEventHandler;
+  onBlur: React.FocusEventHandler;
   style?: React.CSSProperties;
 }
 
@@ -25,6 +29,7 @@ const TabNode: React.FC<TabNodeProps> = props => {
     prefixCls,
     id,
     active,
+    focus,
     tab: { key, label, disabled, closeIcon, icon },
     closable,
     renderWrapper,
@@ -32,6 +37,9 @@ const TabNode: React.FC<TabNodeProps> = props => {
     editable,
     onClick,
     onFocus,
+    onBlur,
+    onKeyDown,
+    onMouseDown,
     style,
   } = props;
   const tabPrefix = `${prefixCls}-tab`;
@@ -56,15 +64,23 @@ const TabNode: React.FC<TabNodeProps> = props => {
     [label, icon],
   );
 
+  function onInternalKeyDown(e: React.KeyboardEvent) {
+    onKeyDown(e);
+    if (e.which === KeyCode.SPACE || e.which === KeyCode.ENTER) {
+      e.preventDefault();
+      onInternalClick(e);
+    }
+  }
+
   const node: React.ReactElement = (
     <div
       key={key}
-      // ref={ref}
       data-node-key={genDataNodeKey(key)}
       className={classNames(tabPrefix, {
         [`${tabPrefix}-with-remove`]: removable,
         [`${tabPrefix}-active`]: active,
         [`${tabPrefix}-disabled`]: disabled,
+        [`${tabPrefix}-focus`]: focus,
       })}
       style={style}
       onClick={onInternalClick}
@@ -77,18 +93,15 @@ const TabNode: React.FC<TabNodeProps> = props => {
         className={`${tabPrefix}-btn`}
         aria-controls={id && `${id}-panel-${key}`}
         aria-disabled={disabled}
-        tabIndex={disabled ? null : 0}
+        tabIndex={disabled ? null : active ? 0 : -1}
         onClick={e => {
           e.stopPropagation();
           onInternalClick(e);
         }}
-        onKeyDown={e => {
-          if ([KeyCode.SPACE, KeyCode.ENTER].includes(e.which)) {
-            e.preventDefault();
-            onInternalClick(e);
-          }
-        }}
+        onKeyDown={onInternalKeyDown}
+        onMouseDown={onMouseDown}
         onFocus={onFocus}
+        onBlur={onBlur}
       >
         {icon && <span className={`${tabPrefix}-icon`}>{icon}</span>}
         {label && labelNode}

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -564,6 +564,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
       <div
         ref={useComposeRef(ref, containerRef)}
         role="tablist"
+        aria-orientation={tabPositionTopOrBottom ? 'horizontal' : 'vertical'}
         className={classNames(`${prefixCls}-nav`, className)}
         style={style}
         onKeyDown={() => {

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import classNames from 'classnames';
 import ResizeObserver from 'rc-resize-observer';
-import KeyCode from 'rc-util/lib/KeyCode';
 import useEvent from 'rc-util/lib/hooks/useEvent';
 import { useComposeRef } from 'rc-util/lib/ref';
 import * as React from 'react';
@@ -330,15 +329,15 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    const { which } = e;
+    const { key } = e;
 
     const isRTL = rtl && isHorizontal;
     const firstEnabledTab = enabledTabs[0];
     const lastEnabledTab = enabledTabs[enabledTabs.length - 1];
 
-    switch (which) {
+    switch (key) {
       // LEFT
-      case KeyCode.LEFT: {
+      case 'ArrowLeft': {
         if (isHorizontal) {
           onOffset(isRTL ? 1 : -1);
         }
@@ -346,7 +345,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
       }
 
       // RIGHT
-      case KeyCode.RIGHT: {
+      case 'ArrowRight': {
         if (isHorizontal) {
           onOffset(isRTL ? -1 : 1);
         }
@@ -354,7 +353,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
       }
 
       // UP
-      case KeyCode.UP: {
+      case 'ArrowUp': {
         e.preventDefault();
         if (!isHorizontal) {
           onOffset(-1);
@@ -363,7 +362,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
       }
 
       // DOWN
-      case KeyCode.DOWN: {
+      case 'ArrowDown': {
         e.preventDefault();
         if (!isHorizontal) {
           onOffset(1);
@@ -372,22 +371,22 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
       }
 
       // HOME
-      case KeyCode.HOME: {
+      case 'Home': {
         e.preventDefault();
         setFocusKey(firstEnabledTab);
         break;
       }
 
       // END
-      case KeyCode.END: {
+      case 'End': {
         e.preventDefault();
         setFocusKey(lastEnabledTab);
         break;
       }
 
       // Enter & Space
-      case KeyCode.ENTER:
-      case KeyCode.SPACE: {
+      case 'Enter':
+      case 'Space': {
         e.preventDefault();
         onTabClick(focusKey, e);
         break;

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -88,8 +88,8 @@ const getSize = (refObj: React.RefObject<HTMLElement>): SizeInfo => {
 /**
  * Convert `SizeInfo` to unit value. Such as [123, 456] with `top` position get `123`
  */
-const getUnitValue = (size: SizeInfo, isHorizontal: boolean) => {
-  return size[isHorizontal ? 0 : 1];
+const getUnitValue = (size: SizeInfo, tabPositionTopOrBottom: boolean) => {
+  return size[tabPositionTopOrBottom ? 0 : 1];
 };
 
 const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref) => {
@@ -120,15 +120,15 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
   const operationsRef = useRef<HTMLDivElement>(null);
   const innerAddButtonRef = useRef<HTMLButtonElement>(null);
 
-  const isHorizontal = tabPosition === 'top' || tabPosition === 'bottom';
+  const tabPositionTopOrBottom = tabPosition === 'top' || tabPosition === 'bottom';
 
   const [transformLeft, setTransformLeft] = useSyncState(0, (next, prev) => {
-    if (isHorizontal && onTabScroll) {
+    if (tabPositionTopOrBottom && onTabScroll) {
       onTabScroll({ direction: next > prev ? 'left' : 'right' });
     }
   });
   const [transformTop, setTransformTop] = useSyncState(0, (next, prev) => {
-    if (!isHorizontal && onTabScroll) {
+    if (!tabPositionTopOrBottom && onTabScroll) {
       onTabScroll({ direction: next > prev ? 'top' : 'bottom' });
     }
   });
@@ -142,10 +142,13 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
   const tabOffsets = useOffsets(tabs, tabSizes, tabContentSize[0]);
 
   // ========================== Unit =========================
-  const containerExcludeExtraSizeValue = getUnitValue(containerExcludeExtraSize, isHorizontal);
-  const tabContentSizeValue = getUnitValue(tabContentSize, isHorizontal);
-  const addSizeValue = getUnitValue(addSize, isHorizontal);
-  const operationSizeValue = getUnitValue(operationSize, isHorizontal);
+  const containerExcludeExtraSizeValue = getUnitValue(
+    containerExcludeExtraSize,
+    tabPositionTopOrBottom,
+  );
+  const tabContentSizeValue = getUnitValue(tabContentSize, tabPositionTopOrBottom);
+  const addSizeValue = getUnitValue(addSize, tabPositionTopOrBottom);
+  const operationSizeValue = getUnitValue(operationSize, tabPositionTopOrBottom);
 
   const needScroll =
     Math.floor(containerExcludeExtraSizeValue) < Math.floor(tabContentSizeValue + addSizeValue);
@@ -159,7 +162,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
   let transformMin = 0;
   let transformMax = 0;
 
-  if (!isHorizontal) {
+  if (!tabPositionTopOrBottom) {
     transformMin = Math.min(0, visibleTabContentValue - tabContentSizeValue);
     transformMax = 0;
   } else if (rtl) {
@@ -208,7 +211,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
       return false;
     }
 
-    if (isHorizontal) {
+    if (tabPositionTopOrBottom) {
       doMove(setTransformLeft, offsetX);
     } else {
       doMove(setTransformTop, offsetY);
@@ -238,7 +241,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
     // Container
     visibleTabContentValue,
     // Transform
-    isHorizontal ? transformLeft : transformTop,
+    tabPositionTopOrBottom ? transformLeft : transformTop,
     // Tabs
     tabContentSizeValue,
     // Add
@@ -258,7 +261,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
       top: 0,
     };
 
-    if (isHorizontal) {
+    if (tabPositionTopOrBottom) {
       // ============ Align with top & bottom ============
       let newTransform = transformLeft;
 
@@ -331,14 +334,14 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
   const handleKeyDown = (e: React.KeyboardEvent) => {
     const { code } = e;
 
-    const isRTL = rtl && isHorizontal;
+    const isRTL = rtl && tabPositionTopOrBottom;
     const firstEnabledTab = enabledTabs[0];
     const lastEnabledTab = enabledTabs[enabledTabs.length - 1];
 
     switch (code) {
       // LEFT
       case 'ArrowLeft': {
-        if (isHorizontal) {
+        if (tabPositionTopOrBottom) {
           onOffset(isRTL ? 1 : -1);
         }
         break;
@@ -346,7 +349,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
 
       // RIGHT
       case 'ArrowRight': {
-        if (isHorizontal) {
+        if (tabPositionTopOrBottom) {
           onOffset(isRTL ? -1 : 1);
         }
         break;
@@ -355,7 +358,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
       // UP
       case 'ArrowUp': {
         e.preventDefault();
-        if (!isHorizontal) {
+        if (!tabPositionTopOrBottom) {
           onOffset(-1);
         }
         break;
@@ -364,7 +367,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
       // DOWN
       case 'ArrowDown': {
         e.preventDefault();
-        if (!isHorizontal) {
+        if (!tabPositionTopOrBottom) {
           onOffset(1);
         }
         break;
@@ -396,7 +399,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
 
   // ========================== Tab ==========================
   const tabNodeStyle: React.CSSProperties = {};
-  if (isHorizontal) {
+  if (tabPositionTopOrBottom) {
     tabNodeStyle[rtl ? 'marginRight' : 'marginLeft'] = tabBarGutter;
   } else {
     tabNodeStyle.marginTop = tabBarGutter;
@@ -505,7 +508,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
   const activeTabOffset = tabOffsets.get(activeKey);
   const { style: indicatorStyle } = useIndicator({
     activeTabOffset,
-    horizontal: isHorizontal,
+    horizontal: tabPositionTopOrBottom,
     indicator,
     rtl,
   });
@@ -519,7 +522,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
     transformMax,
     stringify(activeTabOffset),
     stringify(tabOffsets as any),
-    isHorizontal,
+    tabPositionTopOrBottom,
   ]);
 
   // Should recalculate when rtl changed
@@ -536,7 +539,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
   let pingTop: boolean;
   let pingBottom: boolean;
 
-  if (isHorizontal) {
+  if (tabPositionTopOrBottom) {
     if (rtl) {
       pingRight = transformLeft > 0;
       pingLeft = transformLeft !== transformMax;

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -336,7 +336,6 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
     switch (which) {
       // LEFT
       case KeyCode.LEFT: {
-        e.preventDefault();
         if (isHorizontal) {
           onOffset(isRTL ? 1 : -1);
         }
@@ -345,7 +344,6 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
 
       // RIGHT
       case KeyCode.RIGHT: {
-        e.preventDefault();
         if (isHorizontal) {
           onOffset(isRTL ? -1 : 1);
         }

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -375,7 +375,8 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
         break;
       }
       // Backspace
-      case 'Backspace': {
+      case 'Backspace':
+      case 'Delete': {
         const removeIndex = enabledTabs.indexOf(focusKey);
         const removeTab = tabs.find(tab => tab.key === focusKey);
         const removable = getRemovable(

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -299,6 +299,8 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
   const [focusKey, setFocusKey] = useState<string>();
   const [isKeyboard, setIsKeyboard] = useState(false);
 
+  const enabledTabs = tabs.filter(tab => !tab.disabled).map(tab => tab.key);
+
   useEffect(() => {
     const captureTabKey = (e: KeyboardEvent) => {
       if (e.key === 'Tab') {
@@ -313,7 +315,6 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
   }, []);
 
   const onOffset = (offset: number) => {
-    const enabledTabs = tabs.filter(tab => !tab.disabled).map(tab => tab.key);
     const currentIndex = enabledTabs.indexOf(focusKey || activeKey);
 
     let newIndex = currentIndex + offset;
@@ -332,6 +333,8 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
     const { which } = e;
 
     const isRTL = rtl && isHorizontal;
+    const firstEnabledTab = enabledTabs[0];
+    const lastEnabledTab = enabledTabs[enabledTabs.length - 1];
 
     switch (which) {
       // LEFT
@@ -371,18 +374,14 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
       // HOME
       case KeyCode.HOME: {
         e.preventDefault();
-        const enabledTabs = tabs.filter(tab => !tab.disabled).map(tab => tab.key);
-        const newKey = enabledTabs[0];
-        setFocusKey(newKey);
+        setFocusKey(firstEnabledTab);
         break;
       }
 
       // END
       case KeyCode.END: {
         e.preventDefault();
-        const enabledTabs = tabs.filter(tab => !tab.disabled).map(tab => tab.key);
-        const newKey = enabledTabs[enabledTabs.length - 1];
-        setFocusKey(newKey);
+        setFocusKey(lastEnabledTab);
         break;
       }
 

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -329,13 +329,13 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    const { key } = e;
+    const { code } = e;
 
     const isRTL = rtl && isHorizontal;
     const firstEnabledTab = enabledTabs[0];
     const lastEnabledTab = enabledTabs[enabledTabs.length - 1];
 
-    switch (key) {
+    switch (code) {
       // LEFT
       case 'ArrowLeft': {
         if (isHorizontal) {

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -425,6 +425,8 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
         focus={key === focusKey}
         renderWrapper={children}
         removeAriaLabel={locale?.removeAriaLabel}
+        tabCount={enabledTabs.length}
+        currentPosition={i + 1}
         onClick={e => {
           onTabClick(key, e);
         }}

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -383,6 +383,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
       }
       // Backspace
       case 'Backspace': {
+        const removeIndex = enabledTabs.indexOf(focusKey);
         const removeTab = tabs.find(tab => tab.key === focusKey);
         const removable = getRemovable(
           removeTab?.closable,
@@ -394,8 +395,12 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
           e.preventDefault();
           e.stopPropagation();
           editable.onEdit('remove', { key: focusKey, event: e });
-          // should focus next tab after remove
-          onOffset(1);
+          // when remove last tab, focus previous tab
+          if (removeIndex === enabledTabs.length - 1) {
+            onOffset(-1);
+          } else {
+            onOffset(1);
+          }
         }
         break;
       }

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -299,7 +299,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
 
   // ========================= Focus =========================
   const [focusKey, setFocusKey] = useState<string>();
-  const [isKeyboard, setIsKeyboard] = useState(false);
+  const [isKeyboard, setIsKeyboard] = useState(true);
 
   const enabledTabs = tabs.filter(tab => !tab.disabled).map(tab => tab.key);
 

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -303,19 +303,6 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
 
   const enabledTabs = tabs.filter(tab => !tab.disabled).map(tab => tab.key);
 
-  useEffect(() => {
-    const captureTabKey = (e: KeyboardEvent) => {
-      if (e.key === 'Tab') {
-        setIsKeyboard(true);
-      }
-    };
-
-    window.addEventListener('keydown', captureTabKey);
-    return () => {
-      window.removeEventListener('keydown', captureTabKey);
-    };
-  }, []);
-
   const onOffset = (offset: number) => {
     const currentIndex = enabledTabs.indexOf(focusKey || activeKey);
 
@@ -445,6 +432,9 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
         }}
         onMouseDown={() => {
           setIsKeyboard(false);
+        }}
+        onMouseUp={() => {
+          setIsKeyboard(true);
         }}
       />
     );

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -305,16 +305,9 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
 
   const onOffset = (offset: number) => {
     const currentIndex = enabledTabs.indexOf(focusKey || activeKey);
-
-    let newIndex = currentIndex + offset;
-
-    if (newIndex < 0) {
-      newIndex = enabledTabs.length - 1;
-    } else if (newIndex >= enabledTabs.length) {
-      newIndex = 0;
-    }
-
-    const newKey = enabledTabs[newIndex];
+    const len = enabledTabs.length;
+    const nextIndex = (currentIndex + offset + len) % len;
+    const newKey = enabledTabs[nextIndex];
     setFocusKey(newKey);
   };
 

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -381,6 +381,17 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
         onTabClick(focusKey, e);
         break;
       }
+      // Backspace
+      case 'Backspace': {
+        if (editable) {
+          e.preventDefault();
+          e.stopPropagation();
+          editable.onEdit('remove', { key: focusKey, event: e });
+          // should focus next tab after remove
+          onOffset(1);
+        }
+        break;
+      }
     }
   };
 

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -299,7 +299,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
 
   // ========================= Focus =========================
   const [focusKey, setFocusKey] = useState<string>();
-  const [isKeyboard, setIsKeyboard] = useState(true);
+  const [isMouse, setIsMouse] = useState(false);
 
   const enabledTabs = tabs.filter(tab => !tab.disabled).map(tab => tab.key);
 
@@ -432,7 +432,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
         }}
         onKeyDown={handleKeyDown}
         onFocus={() => {
-          if (isKeyboard) {
+          if (!isMouse) {
             setFocusKey(key);
           }
           scrollToTab(key);
@@ -450,10 +450,10 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
           setFocusKey(undefined);
         }}
         onMouseDown={() => {
-          setIsKeyboard(false);
+          setIsMouse(true);
         }}
         onMouseUp={() => {
-          setIsKeyboard(true);
+          setIsMouse(false);
         }}
       />
     );

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -25,7 +25,7 @@ import type {
   TabSizeMap,
   TabsLocale,
 } from '../interface';
-import { genDataNodeKey, stringify } from '../util';
+import { genDataNodeKey, getRemovable, stringify } from '../util';
 import AddButton from './AddButton';
 import ExtraContent from './ExtraContent';
 import OperationNode from './OperationNode';
@@ -383,7 +383,14 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
       }
       // Backspace
       case 'Backspace': {
-        if (editable) {
+        const removeTab = tabs.find(tab => tab.key === focusKey);
+        const removable = getRemovable(
+          removeTab?.closable,
+          removeTab?.closeIcon,
+          editable,
+          removeTab?.disabled,
+        );
+        if (removable) {
           e.preventDefault();
           e.stopPropagation();
           editable.onEdit('remove', { key: focusKey, event: e });

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`Tabs.Basic Normal 1`] = `
             class="rc-tabs-tab-btn"
             id="rc-tabs-test-tab-light"
             role="tab"
-            tabindex="0"
+            tabindex="-1"
           >
             light
           </div>
@@ -55,7 +55,7 @@ exports[`Tabs.Basic Normal 1`] = `
             class="rc-tabs-tab-btn"
             id="rc-tabs-test-tab-cute"
             role="tab"
-            tabindex="0"
+            tabindex="-1"
           >
             cute
           </div>

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -18,13 +18,13 @@ exports[`Tabs.Basic Normal 1`] = `
         <div
           class="rc-tabs-tab"
           data-node-key="light"
+          role="tab"
         >
           <div
             aria-controls="rc-tabs-test-panel-light"
             aria-selected="false"
             class="rc-tabs-tab-btn"
             id="rc-tabs-test-tab-light"
-            role="tab"
             tabindex="-1"
           >
             light
@@ -33,13 +33,13 @@ exports[`Tabs.Basic Normal 1`] = `
         <div
           class="rc-tabs-tab rc-tabs-tab-active"
           data-node-key="bamboo"
+          role="tab"
         >
           <div
             aria-controls="rc-tabs-test-panel-bamboo"
             aria-selected="true"
             class="rc-tabs-tab-btn"
             id="rc-tabs-test-tab-bamboo"
-            role="tab"
             tabindex="0"
           >
             bamboo
@@ -48,13 +48,13 @@ exports[`Tabs.Basic Normal 1`] = `
         <div
           class="rc-tabs-tab"
           data-node-key="cute"
+          role="tab"
         >
           <div
             aria-controls="rc-tabs-test-panel-cute"
             aria-selected="false"
             class="rc-tabs-tab-btn"
             id="rc-tabs-test-tab-cute"
-            role="tab"
             tabindex="-1"
           >
             cute
@@ -122,13 +122,13 @@ exports[`Tabs.Basic Skip invalidate children 1`] = `
         <div
           class="rc-tabs-tab rc-tabs-tab-active"
           data-node-key="light"
+          role="tab"
         >
           <div
             aria-controls="rc-tabs-test-panel-light"
             aria-selected="true"
             class="rc-tabs-tab-btn"
             id="rc-tabs-test-tab-light"
-            role="tab"
             tabindex="0"
           >
             light

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -18,13 +18,13 @@ exports[`Tabs.Basic Normal 1`] = `
         <div
           class="rc-tabs-tab"
           data-node-key="light"
-          role="tab"
         >
           <div
             aria-controls="rc-tabs-test-panel-light"
             aria-selected="false"
             class="rc-tabs-tab-btn"
             id="rc-tabs-test-tab-light"
+            role="tab"
             tabindex="-1"
           >
             light
@@ -33,13 +33,13 @@ exports[`Tabs.Basic Normal 1`] = `
         <div
           class="rc-tabs-tab rc-tabs-tab-active"
           data-node-key="bamboo"
-          role="tab"
         >
           <div
             aria-controls="rc-tabs-test-panel-bamboo"
             aria-selected="true"
             class="rc-tabs-tab-btn"
             id="rc-tabs-test-tab-bamboo"
+            role="tab"
             tabindex="0"
           >
             bamboo
@@ -48,13 +48,13 @@ exports[`Tabs.Basic Normal 1`] = `
         <div
           class="rc-tabs-tab"
           data-node-key="cute"
-          role="tab"
         >
           <div
             aria-controls="rc-tabs-test-panel-cute"
             aria-selected="false"
             class="rc-tabs-tab-btn"
             id="rc-tabs-test-tab-cute"
+            role="tab"
             tabindex="-1"
           >
             cute
@@ -122,13 +122,13 @@ exports[`Tabs.Basic Skip invalidate children 1`] = `
         <div
           class="rc-tabs-tab rc-tabs-tab-active"
           data-node-key="light"
-          role="tab"
         >
           <div
             aria-controls="rc-tabs-test-panel-light"
             aria-selected="true"
             class="rc-tabs-tab-btn"
             id="rc-tabs-test-tab-light"
+            role="tab"
             tabindex="0"
           >
             light

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`Tabs.Basic Normal 1`] = `
   class="rc-tabs rc-tabs-top"
 >
   <div
+    aria-orientation="horizontal"
     class="rc-tabs-nav"
     role="tablist"
   >
@@ -109,6 +110,7 @@ exports[`Tabs.Basic Skip invalidate children 1`] = `
   class="rc-tabs rc-tabs-top"
 >
   <div
+    aria-orientation="horizontal"
     class="rc-tabs-nav"
     role="tablist"
   >

--- a/tests/accessibility.test.tsx
+++ b/tests/accessibility.test.tsx
@@ -99,7 +99,7 @@ describe('Tabs.Accessibility', () => {
     await user.tab();
 
     // activate tab
-    await user.keyboard('{Space}');
+    await user.keyboard(' ');
     expect(onTabClick).toHaveBeenCalledTimes(1);
 
     // move focus to second tab

--- a/tests/accessibility.test.tsx
+++ b/tests/accessibility.test.tsx
@@ -232,6 +232,11 @@ describe('Tabs.Accessibility', () => {
           label: 'Tab 2',
           children: 'Content 2',
         },
+        {
+          key: '3',
+          label: 'Tab 3',
+          children: 'Content 3',
+        },
       ]);
       return (
         <Tabs
@@ -256,6 +261,9 @@ describe('Tabs.Accessibility', () => {
 
     await user.keyboard('{Backspace}');
     expect(queryByRole('tab', { name: 'Tab 2' })).toBeNull();
+
+    await user.keyboard('{Delete}');
+    expect(queryByRole('tab', { name: 'Tab 3' })).toBeNull();
 
     const firstTab = getByRole('tab', { name: 'Tab 1' });
     expect(firstTab).toHaveFocus();

--- a/tests/accessibility.test.tsx
+++ b/tests/accessibility.test.tsx
@@ -148,4 +148,73 @@ describe('Tabs.Accessibility', () => {
     // skip disabled tab
     expect(fourthTab.parentElement).toHaveClass('rc-tabs-tab-focus');
   });
+
+  it('should support keyboard delete tab', async () => {
+    const user = userEvent.setup();
+    const Demo = () => {
+      const [items, setItems] = React.useState([
+        {
+          key: '1',
+          label: 'Tab 1',
+          children: 'Content 1',
+        },
+        {
+          key: '2',
+          label: 'Tab 2',
+          children: 'Content 2',
+        },
+        {
+          key: '3',
+          label: 'Tab 3',
+          disabled: true,
+          children: 'Content 3',
+        },
+        {
+          key: '4',
+          label: 'Tab 4',
+          children: 'Content 4',
+        },
+      ]);
+      return (
+        <Tabs
+          defaultActiveKey="1"
+          items={items}
+          editable={{
+            onEdit: (type, { key }) => {
+              if (type === 'remove') {
+                setItems(prevItems => prevItems.filter(item => item.key !== key));
+              }
+            },
+          }}
+        />
+      );
+    };
+
+    const { getByRole, queryByRole } = render(<Demo />);
+
+    // focus to first tab
+    await user.tab();
+    const firstTab = getByRole('tab', { name: 'Tab 1' });
+    expect(firstTab).toHaveFocus();
+
+    // delete first tab
+    await user.keyboard('{Backspace}');
+    expect(queryByRole('tab', { name: 'Tab 1' })).toBeNull();
+
+    // focus should move to next tab
+    const secondTab = getByRole('tab', { name: 'Tab 2' });
+    expect(secondTab).toHaveFocus();
+
+    // delete second tab
+    await user.keyboard('{Backspace}');
+    expect(queryByRole('tab', { name: 'Tab 2' })).toBeNull();
+
+    // focus should move to next tab
+    const fourthTab = getByRole('tab', { name: 'Tab 4' });
+    expect(fourthTab).toHaveFocus();
+
+    // keyboard navigation should work
+    await user.keyboard('{ArrowRight}');
+    expect(fourthTab.parentElement).toHaveClass('rc-tabs-tab-focus');
+  });
 });

--- a/tests/accessibility.test.tsx
+++ b/tests/accessibility.test.tsx
@@ -12,23 +12,23 @@ describe('Tabs.Accessibility', () => {
       items={[
         {
           key: '1',
-          label: 'Tab 1',
+          label: 'Tab1',
           children: 'Content 1',
         },
         {
           key: '2',
-          label: 'Tab 2',
+          label: 'Tab2',
           children: 'Content 2',
         },
         {
           key: '3',
-          label: 'Tab 3',
+          label: 'Tab3',
           disabled: true,
           children: 'Content 3',
         },
         {
           key: '4',
-          label: 'Tab 4',
+          label: 'Tab4',
           children: 'Content 4',
         },
       ]}
@@ -39,9 +39,9 @@ describe('Tabs.Accessibility', () => {
     const user = userEvent.setup();
     const { getByRole } = render(createTabs());
 
-    const firstTab = getByRole('tab', { name: 'Tab 1' });
-    const secondTab = getByRole('tab', { name: 'Tab 2' });
-    const fourthTab = getByRole('tab', { name: 'Tab 4' });
+    const firstTab = getByRole('tab', { name: /Tab1/i });
+    const secondTab = getByRole('tab', { name: /Tab2/i });
+    const fourthTab = getByRole('tab', { name: /Tab4/i });
 
     await user.tab();
     expect(firstTab).toHaveFocus();
@@ -76,12 +76,12 @@ describe('Tabs.Accessibility', () => {
 
     // jump to first tab
     await user.tab();
-    const firstTab = getByRole('tab', { name: 'Tab 1' });
+    const firstTab = getByRole('tab', { name: /Tab1/i });
     expect(firstTab).toHaveFocus();
 
     // move to second tab
     await user.keyboard('{ArrowDown}');
-    const secondTab = getByRole('tab', { name: 'Tab 2' });
+    const secondTab = getByRole('tab', { name: /Tab2/i });
     expect(secondTab.parentElement).toHaveClass('rc-tabs-tab-focus');
 
     // move to first tab
@@ -121,7 +121,7 @@ describe('Tabs.Accessibility', () => {
     await user.keyboard('{ArrowRight}');
     await user.keyboard('{ArrowRight}');
 
-    const fourthTab = getByRole('tab', { name: 'Tab 4' });
+    const fourthTab = getByRole('tab', { name: /Tab4/i });
     expect(fourthTab.parentElement).toHaveClass('rc-tabs-tab-focus');
   });
 
@@ -129,8 +129,8 @@ describe('Tabs.Accessibility', () => {
     const user = userEvent.setup();
     const { getByRole } = render(createTabs());
 
-    const secondTab = getByRole('tab', { name: 'Tab 2' });
-    const fourthTab = getByRole('tab', { name: 'Tab 4' });
+    const secondTab = getByRole('tab', { name: /Tab2/i });
+    const fourthTab = getByRole('tab', { name: /Tab4/i });
 
     // mouse click should not add focus style
     await user.click(secondTab);
@@ -155,23 +155,23 @@ describe('Tabs.Accessibility', () => {
       const [items, setItems] = React.useState([
         {
           key: '1',
-          label: 'Tab 1',
+          label: 'Tab1',
           children: 'Content 1',
         },
         {
           key: '2',
-          label: 'Tab 2',
+          label: 'Tab2',
           children: 'Content 2',
         },
         {
           key: '3',
-          label: 'Tab 3',
+          label: 'Tab3',
           disabled: true,
           children: 'Content 3',
         },
         {
           key: '4',
-          label: 'Tab 4',
+          label: 'Tab4',
           children: 'Content 4',
         },
       ]);
@@ -194,23 +194,23 @@ describe('Tabs.Accessibility', () => {
 
     // focus to first tab
     await user.tab();
-    const firstTab = getByRole('tab', { name: 'Tab 1' });
+    const firstTab = getByRole('tab', { name: /Tab1/i });
     expect(firstTab).toHaveFocus();
 
     // delete first tab
     await user.keyboard('{Backspace}');
-    expect(queryByRole('tab', { name: 'Tab 1' })).toBeNull();
+    expect(queryByRole('tab', { name: /Tab1/i })).toBeNull();
 
     // focus should move to next tab
-    const secondTab = getByRole('tab', { name: 'Tab 2' });
+    const secondTab = getByRole('tab', { name: /Tab2/i });
     expect(secondTab).toHaveFocus();
 
     // delete second tab
     await user.keyboard('{Backspace}');
-    expect(queryByRole('tab', { name: 'Tab 2' })).toBeNull();
+    expect(queryByRole('tab', { name: /Tab2/i })).toBeNull();
 
     // focus should move to next tab
-    const fourthTab = getByRole('tab', { name: 'Tab 4' });
+    const fourthTab = getByRole('tab', { name: /Tab4/i });
     expect(fourthTab).toHaveFocus();
 
     // keyboard navigation should work
@@ -224,17 +224,17 @@ describe('Tabs.Accessibility', () => {
       const [items, setItems] = React.useState([
         {
           key: '1',
-          label: 'Tab 1',
+          label: 'Tab1',
           children: 'Content 1',
         },
         {
           key: '2',
-          label: 'Tab 2',
+          label: 'Tab2',
           children: 'Content 2',
         },
         {
           key: '3',
-          label: 'Tab 3',
+          label: 'Tab3',
           children: 'Content 3',
         },
       ]);
@@ -256,16 +256,16 @@ describe('Tabs.Accessibility', () => {
     const { getByRole, queryByRole } = render(<Demo />);
 
     await user.tab();
-    const lastTab = getByRole('tab', { name: 'Tab 2' });
-    expect(lastTab).toHaveFocus();
+    const secondTab = getByRole('tab', { name: /Tab2/i });
+    expect(secondTab).toHaveFocus();
 
     await user.keyboard('{Backspace}');
-    expect(queryByRole('tab', { name: 'Tab 2' })).toBeNull();
+    expect(queryByRole('tab', { name: /Tab2/i })).toBeNull();
 
     await user.keyboard('{Delete}');
-    expect(queryByRole('tab', { name: 'Tab 3' })).toBeNull();
+    expect(queryByRole('tab', { name: /Tab3/i })).toBeNull();
 
-    const firstTab = getByRole('tab', { name: 'Tab 1' });
+    const firstTab = getByRole('tab', { name: /Tab1/i });
     expect(firstTab).toHaveFocus();
   });
 });

--- a/tests/accessibility.test.tsx
+++ b/tests/accessibility.test.tsx
@@ -217,4 +217,47 @@ describe('Tabs.Accessibility', () => {
     await user.keyboard('{ArrowRight}');
     expect(fourthTab.parentElement).toHaveClass('rc-tabs-tab-focus');
   });
+
+  it('should focus previous tab when deleting the last tab', async () => {
+    const user = userEvent.setup();
+    const Demo = () => {
+      const [items, setItems] = React.useState([
+        {
+          key: '1',
+          label: 'Tab 1',
+          children: 'Content 1',
+        },
+        {
+          key: '2',
+          label: 'Tab 2',
+          children: 'Content 2',
+        },
+      ]);
+      return (
+        <Tabs
+          defaultActiveKey="2"
+          items={items}
+          editable={{
+            onEdit: (type, { key }) => {
+              if (type === 'remove') {
+                setItems(prevItems => prevItems.filter(item => item.key !== key));
+              }
+            },
+          }}
+        />
+      );
+    };
+
+    const { getByRole, queryByRole } = render(<Demo />);
+
+    await user.tab();
+    const lastTab = getByRole('tab', { name: 'Tab 2' });
+    expect(lastTab).toHaveFocus();
+
+    await user.keyboard('{Backspace}');
+    expect(queryByRole('tab', { name: 'Tab 2' })).toBeNull();
+
+    const firstTab = getByRole('tab', { name: 'Tab 1' });
+    expect(firstTab).toHaveFocus();
+  });
 });

--- a/tests/accessibility.test.tsx
+++ b/tests/accessibility.test.tsx
@@ -1,0 +1,151 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import type { TabsProps } from '../src';
+import Tabs from '../src';
+
+describe('Tabs.Accessibility', () => {
+  const createTabs = (props: TabsProps = {}) => (
+    <Tabs
+      defaultActiveKey="1"
+      {...props}
+      items={[
+        {
+          key: '1',
+          label: 'Tab 1',
+          children: 'Content 1',
+        },
+        {
+          key: '2',
+          label: 'Tab 2',
+          children: 'Content 2',
+        },
+        {
+          key: '3',
+          label: 'Tab 3',
+          disabled: true,
+          children: 'Content 3',
+        },
+        {
+          key: '4',
+          label: 'Tab 4',
+          children: 'Content 4',
+        },
+      ]}
+    />
+  );
+
+  it('should support keyboard navigation', async () => {
+    const user = userEvent.setup();
+    const { getByRole } = render(createTabs());
+
+    const firstTab = getByRole('tab', { name: 'Tab 1' });
+    const secondTab = getByRole('tab', { name: 'Tab 2' });
+    const fourthTab = getByRole('tab', { name: 'Tab 4' });
+
+    await user.tab();
+    expect(firstTab).toHaveFocus();
+
+    await user.keyboard('{ArrowRight}');
+    expect(secondTab.parentElement).toHaveClass('rc-tabs-tab-focus');
+
+    // skip disabled tab
+    await user.keyboard('{ArrowRight}');
+    expect(fourthTab.parentElement).toHaveClass('rc-tabs-tab-focus');
+
+    // cycle to first tab
+    await user.keyboard('{ArrowRight}');
+    expect(firstTab.parentElement).toHaveClass('rc-tabs-tab-focus');
+
+    // cycle to last tab
+    await user.keyboard('{ArrowLeft}');
+    expect(fourthTab.parentElement).toHaveClass('rc-tabs-tab-focus');
+
+    // jump to first tab
+    await user.keyboard('{Home}');
+    expect(firstTab.parentElement).toHaveClass('rc-tabs-tab-focus');
+
+    // jump to last tab
+    await user.keyboard('{End}');
+    expect(fourthTab.parentElement).toHaveClass('rc-tabs-tab-focus');
+  });
+
+  it('should support vertical keyboard navigation', async () => {
+    const user = userEvent.setup();
+    const { getByRole } = render(createTabs({ tabPosition: 'left' }));
+
+    // jump to first tab
+    await user.tab();
+    const firstTab = getByRole('tab', { name: 'Tab 1' });
+    expect(firstTab).toHaveFocus();
+
+    // move to second tab
+    await user.keyboard('{ArrowDown}');
+    const secondTab = getByRole('tab', { name: 'Tab 2' });
+    expect(secondTab.parentElement).toHaveClass('rc-tabs-tab-focus');
+
+    // move to first tab
+    await user.keyboard('{ArrowUp}');
+    expect(firstTab.parentElement).toHaveClass('rc-tabs-tab-focus');
+  });
+
+  it('should activate tab on Enter/Space', async () => {
+    const onTabClick = jest.fn();
+    const user = userEvent.setup();
+
+    render(createTabs({ onTabClick }));
+
+    // jump to first tab
+    await user.tab();
+
+    // activate tab
+    await user.keyboard('{Space}');
+    expect(onTabClick).toHaveBeenCalledTimes(1);
+
+    // move focus to second tab
+    await user.keyboard('{ArrowRight}');
+
+    // activate tab
+    await user.keyboard('{Enter}');
+    expect(onTabClick).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not navigate to disabled tabs', async () => {
+    const user = userEvent.setup();
+    const { getByRole } = render(createTabs());
+
+    // jump to first tab
+    await user.tab();
+
+    // should skip disabled tab
+    await user.keyboard('{ArrowRight}');
+    await user.keyboard('{ArrowRight}');
+
+    const fourthTab = getByRole('tab', { name: 'Tab 4' });
+    expect(fourthTab.parentElement).toHaveClass('rc-tabs-tab-focus');
+  });
+
+  it('should distinguish between keyboard and mouse navigation', async () => {
+    const user = userEvent.setup();
+    const { getByRole } = render(createTabs());
+
+    const secondTab = getByRole('tab', { name: 'Tab 2' });
+    const fourthTab = getByRole('tab', { name: 'Tab 4' });
+
+    // mouse click should not add focus style
+    await user.click(secondTab);
+    expect(secondTab.parentElement).not.toHaveClass('rc-tabs-tab-focus');
+
+    // clear focus
+    await user.click(document.body);
+
+    // keyboard navigation should add focus style
+    await user.tab();
+    // default focus active tab
+    expect(secondTab.parentElement).toHaveClass('rc-tabs-tab-focus');
+
+    await user.keyboard('{ArrowRight}');
+    // skip disabled tab
+    expect(fourthTab.parentElement).toHaveClass('rc-tabs-tab-focus');
+  });
+});

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,6 +1,5 @@
 import '@testing-library/dom';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import KeyCode from 'rc-util/lib/KeyCode';
 import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
 import React from 'react';
 import Tabs from '../src';
@@ -25,6 +24,7 @@ describe('Tabs.Basic', () => {
   const hackOffsetInfo: HackInfo = {};
 
   beforeEach(() => {
+    jest.useFakeTimers();
     Object.keys(hackOffsetInfo).forEach(key => {
       delete hackOffsetInfo[key];
     });
@@ -215,15 +215,6 @@ describe('Tabs.Basic', () => {
         name: 'inner button',
         trigger: container =>
           fireEvent.click(container.querySelectorAll('.rc-tabs-tab .rc-tabs-tab-btn')[2]),
-      },
-      {
-        name: 'inner button key down',
-        trigger: container =>
-          fireEvent.keyDown(container.querySelectorAll('.rc-tabs-tab .rc-tabs-tab-btn')[2], {
-            which: KeyCode.SPACE,
-            keyCode: KeyCode.SPACE,
-            charCode: KeyCode.SPACE,
-          }),
       },
     ];
 


### PR DESCRIPTION
# 🚀 为 Tabs 组件添加焦点管理和键盘导航能力

## 📝 功能描述

为 Tabs 组件添加了焦点管理并增强了键盘导航能力，以提升组件的可访问性和用户体验。

### 主要特性

- 添加键盘焦点追踪和管理
- 实现完整的键盘导航支持：
  - 水平标签页支持左右方向键
  - 垂直标签页支持上下方向键
  - Home/End 键快速跳转到首尾标签
  - Enter/Space 键激活标签
- 支持 RTL（从右到左）布局下的键盘导航
- 为键盘导航添加视觉焦点指示器
- 维护鼠标和键盘操作之间的焦点状态

### 键盘导航说明

- **水平标签页**:
  - 左右方向键：在标签间导航
  - Home：跳转到第一个标签
  - End：跳转到最后一个标签
  - Enter/Space：激活当前焦点标签

- **垂直标签页**:
  - 上下方向键：在标签间导航
  - Home：跳转到第一个标签
  - End：跳转到最后一个标签
  - Enter/Space：激活当前焦点标签

### 录屏
![rc-tabs](https://github.com/user-attachments/assets/f4f95c50-d025-4d61-a284-a4ba81d18c5d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新特性**
  - 增加了新的标签项“Yo”，并支持动态切换文本方向。
  - 改进了标签组件的键盘导航，增强了可访问性。
  - 添加了焦点管理和事件处理功能。

- **样式**
  - 优化了标签的样式结构，改善了布局和视觉反馈。

- **测试**
  - 简化了测试用例，专注于关键功能，去除了不必要的事件处理测试。
  - 新增了可访问性测试，确保键盘导航的有效性。
  - 引入了新的测试库以支持用户事件模拟。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->