### PR TITLE
fix: improve TabPane accessibility and content handling

### DIFF
--- a/src/TabPanelList/TabPane.tsx
+++ b/src/TabPanelList/TabPane.tsx
@@ -23,11 +23,13 @@ export interface TabPaneProps {
 
 const TabPane = React.forwardRef<HTMLDivElement, TabPaneProps>((props, ref) => {
   const { prefixCls, className, style, id, active, tabKey, children } = props;
+  const hasContent = React.Children.count(children) > 0;
+
   return (
     <div
       id={id && `${id}-panel-${tabKey}`}
       role="tabpanel"
-      tabIndex={active ? 0 : -1}
+      tabIndex={active && hasContent ? 0 : -1}
       aria-labelledby={id && `${id}-tab-${tabKey}`}
       aria-hidden={!active}
       style={style}

--- a/tests/accessibility.test.tsx
+++ b/tests/accessibility.test.tsx
@@ -268,4 +268,16 @@ describe('Tabs.Accessibility', () => {
     const firstTab = getByRole('tab', { name: /Tab1/i });
     expect(firstTab).toHaveFocus();
   });
+
+  it('should not focus on tab panel when it is empty', async () => {
+    const user = userEvent.setup();
+    const { getByRole } = render(
+      <Tabs defaultActiveKey="1" items={[{ key: '1', label: 'Tab1', children: null }]} />,
+    );
+
+    const tabPanel = getByRole('tabpanel', { name: /Tab1/i });
+    await user.tab();
+    await user.tab();
+    expect(tabPanel).not.toHaveFocus();
+  });
 });


### PR DESCRIPTION
![QQ_1739612834107](https://github.com/user-attachments/assets/0c62848c-c1b9-41d8-a75e-d19e30b82076)

页签卡片复用了tabs组件，但是tabs children始终为空，需要特殊处理一下focus的情况

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 优化了选项卡面板的焦点管理，现仅在面板处于激活状态且包含内容时设置为可聚焦，从而改善用户的导航体验。
- **Bug Fixes**
	- 新增测试用例，确保当选项卡面板为空时不会获得焦点，从而增强可访问性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->