### PR TITLE
feat: tab support classnames and styles

### DIFF
--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -573,8 +573,8 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
         ref={useComposeRef(ref, containerRef)}
         role="tablist"
         aria-orientation={tabPositionTopOrBottom ? 'horizontal' : 'vertical'}
-        className={classNames(`${prefixCls}-nav`, className)}
-        style={style}
+        className={classNames(`${prefixCls}-nav`, className, tabsClassNames?.header)}
+        style={{ ...styles?.header, ...style }}
         onKeyDown={() => {
           // No need animation when use keyboard
           doLockAnimation();

--- a/src/TabPanelList/index.tsx
+++ b/src/TabPanelList/index.tsx
@@ -11,10 +11,20 @@ export interface TabPanelListProps {
   animated?: AnimatedConfig;
   tabPosition?: TabPosition;
   destroyInactiveTabPane?: boolean;
+  contentStyle?: React.CSSProperties;
+  contentClassName?: string;
 }
 
 const TabPanelList: React.FC<TabPanelListProps> = props => {
-  const { id, activeKey, animated, tabPosition, destroyInactiveTabPane } = props;
+  const {
+    id,
+    activeKey,
+    animated,
+    tabPosition,
+    destroyInactiveTabPane,
+    contentStyle,
+    contentClassName,
+  } = props;
   const { prefixCls, tabs } = React.useContext(TabContext);
   const tabPaneAnimated = animated.tabPane;
 
@@ -54,8 +64,8 @@ const TabPanelList: React.FC<TabPanelListProps> = props => {
                   tabKey={key}
                   animated={tabPaneAnimated}
                   active={active}
-                  style={{ ...paneStyle, ...motionStyle }}
-                  className={classNames(paneClassName, motionClassName)}
+                  style={{ ...contentStyle, ...paneStyle, ...motionStyle }}
+                  className={classNames(contentClassName, paneClassName, motionClassName)}
                   ref={ref}
                 />
               )}

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -34,7 +34,7 @@ import type {
 // Used for accessibility
 let uuid = 0;
 
-export type SemanticName = 'popup' | 'item' | 'indicator';
+export type SemanticName = 'popup' | 'item' | 'indicator' | 'content';
 
 export interface TabsProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'children'> {
@@ -186,9 +186,9 @@ const Tabs = React.forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
     style: tabBarStyle,
     getPopupContainer,
     popupClassName: classNames(popupClassName, tabsClassNames?.popup),
+    indicator,
     styles,
     classNames: tabsClassNames,
-    indicator,
   };
 
   return (
@@ -212,6 +212,8 @@ const Tabs = React.forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
         <TabPanelList
           destroyInactiveTabPane={destroyInactiveTabPane}
           {...sharedProps}
+          contentStyle={styles?.content}
+          contentClassName={tabsClassNames?.content}
           animated={mergedAnimated}
         />
       </div>

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -34,7 +34,7 @@ import type {
 // Used for accessibility
 let uuid = 0;
 
-export type SemanticName = 'popup' | 'item' | 'indicator' | 'content';
+export type SemanticName = 'popup' | 'item' | 'indicator' | 'content' | 'header';
 
 export interface TabsProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'children'> {

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -693,10 +693,12 @@ describe('Tabs.Basic', () => {
     const customClassNames = {
       indicator: 'custom-indicator',
       item: 'custom-item',
+      content: 'custom-content',
     };
     const customStyles = {
       indicator: { background: 'red' },
       item: { color: 'blue' },
+      content: { background: 'green' },
     };
     const { container } = render(
       <Tabs
@@ -708,10 +710,13 @@ describe('Tabs.Basic', () => {
     );
     const indicator = container.querySelector('.rc-tabs-ink-bar') as HTMLElement;
     const item = container.querySelector('.rc-tabs-tab') as HTMLElement;
+    const content = container.querySelector('.rc-tabs-tabpane') as HTMLElement;
 
     expect(indicator).toHaveClass('custom-indicator');
     expect(item).toHaveClass('custom-item');
+    expect(content).toHaveClass('custom-content');
     expect(indicator).toHaveStyle({ background: 'red' });
     expect(item).toHaveStyle({ color: 'blue' });
+    expect(content).toHaveStyle({ background: 'green' });
   });
 });

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -694,11 +694,13 @@ describe('Tabs.Basic', () => {
       indicator: 'custom-indicator',
       item: 'custom-item',
       content: 'custom-content',
+      header: 'custom-header',
     };
     const customStyles = {
       indicator: { background: 'red' },
       item: { color: 'blue' },
       content: { background: 'green' },
+      header: { background: 'yellow' },
     };
     const { container } = render(
       <Tabs
@@ -711,12 +713,16 @@ describe('Tabs.Basic', () => {
     const indicator = container.querySelector('.rc-tabs-ink-bar') as HTMLElement;
     const item = container.querySelector('.rc-tabs-tab') as HTMLElement;
     const content = container.querySelector('.rc-tabs-tabpane') as HTMLElement;
+    const header = container.querySelector('.rc-tabs-nav') as HTMLElement;
 
     expect(indicator).toHaveClass('custom-indicator');
     expect(item).toHaveClass('custom-item');
     expect(content).toHaveClass('custom-content');
+    expect(header).toHaveClass('custom-header');
+
     expect(indicator).toHaveStyle({ background: 'red' });
     expect(item).toHaveStyle({ color: 'blue' });
     expect(content).toHaveStyle({ background: 'green' });
+    expect(header).toHaveStyle({ background: 'yellow' });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新增功能**
  - 添加了用于自定义选项卡内容区域外观的配置选项，允许用户设置样式与样式类。
  - 扩展了组件语义标签，进一步增强了个性化定制能力。

- **测试**
  - 更新了测试用例，验证自定义样式和样式类的应用效果，确保组件外观调整正常显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->