### PR TITLE
fix: Memory leak caused by zombie event listeners in useTouchMove.ts

### DIFF
--- a/src/hooks/useTouchMove.ts
+++ b/src/hooks/useTouchMove.ts
@@ -110,6 +110,8 @@ export default function useTouchMove(
   touchEventsRef.current = { onTouchStart, onTouchMove, onTouchEnd, onWheel };
 
   React.useEffect(() => {
+    const abortController = new AbortController();
+
     function onProxyTouchStart(e: TouchEvent) {
       touchEventsRef.current.onTouchStart(e);
     }
@@ -123,16 +125,26 @@ export default function useTouchMove(
       touchEventsRef.current.onWheel(e);
     }
 
-    document.addEventListener('touchmove', onProxyTouchMove, { passive: false });
-    document.addEventListener('touchend', onProxyTouchEnd, { passive: true });
+    document.addEventListener('touchmove', onProxyTouchMove, {
+      passive: false,
+      signal: abortController.signal,
+    });
+    document.addEventListener('touchend', onProxyTouchEnd, {
+      passive: true,
+      signal: abortController.signal,
+    });
 
-    // No need to clean up since element removed
-    ref.current.addEventListener('touchstart', onProxyTouchStart, { passive: true });
-    ref.current.addEventListener('wheel', onProxyWheel, { passive: false });
+    ref.current.addEventListener('touchstart', onProxyTouchStart, {
+      passive: true,
+      signal: abortController.signal,
+    });
+    ref.current.addEventListener('wheel', onProxyWheel, {
+      passive: false,
+      signal: abortController.signal,
+    });
 
     return () => {
-      document.removeEventListener('touchmove', onProxyTouchMove);
-      document.removeEventListener('touchend', onProxyTouchEnd);
+      abortController.abort();
     };
   }, []);
 }


### PR DESCRIPTION
The code was smelly and it causes a memory leak, even if component is unmounted it will keep the whole context inside Detached Event Listener
 
 
![image](https://github.com/user-attachments/assets/a14365b5-afbd-4397-b970-8c7093dafd43)
