### PR TITLE
fix: dropdown menu missing first tab in overflow edge case

### DIFF
--- a/src/hooks/useVisibleRange.ts
+++ b/src/hooks/useVisibleRange.ts
@@ -38,7 +38,10 @@ export default function useVisibleRange(
     let endIndex = len;
     for (let i = 0; i < len; i += 1) {
       const offset = tabOffsets.get(tabs[i].key) || DEFAULT_SIZE;
-      if (Math.floor(offset[position] + offset[charUnit]) > Math.floor(transformSize + visibleTabContentValue)) {
+      if (
+        Math.floor(offset[position] + offset[charUnit]) >
+        Math.floor(transformSize + visibleTabContentValue)
+      ) {
         endIndex = i - 1;
         break;
       }
@@ -53,7 +56,7 @@ export default function useVisibleRange(
       }
     }
 
-    return startIndex >= endIndex ? [0, -1] : [startIndex, endIndex];
+    return startIndex > endIndex ? [0, -1] : [startIndex, endIndex];
   }, [
     tabOffsets,
     visibleTabContentValue,

--- a/src/hooks/useVisibleRange.ts
+++ b/src/hooks/useVisibleRange.ts
@@ -53,7 +53,7 @@ export default function useVisibleRange(
       }
     }
 
-    return startIndex >= endIndex ? [0, 0] : [startIndex, endIndex];
+    return startIndex >= endIndex ? [0, -1] : [startIndex, endIndex];
   }, [
     tabOffsets,
     visibleTabContentValue,


### PR DESCRIPTION
### 🐛 [问题描述](https://github.com/ant-design/ant-design/issues/54383)
当所有标签页都滚动出可见区域时，`useVisibleRange` 返回 `[0, 0]` 导致第一个标签页被错误地排除在隐藏标签页列表之外，使得 dropdown 菜单不完整。

close https://github.com/ant-design/ant-design/issues/54383
close https://github.com/react-component/tabs/issues/862

### 🔧 解决方案
将边界情况的返回值从 `[0, 0]` 修改为 `[0, -1]`，确保：
- `startHiddenTabs = tabs.slice(0, 0) = []` 
- `endHiddenTabs = tabs.slice(-1+1) = [所有标签页]`
- 所有标签页都正确出现在 dropdown 菜单中

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Bug Fixes**
  * 修正了当计算出的可见范围起始索引严格大于结束索引时的返回值，更明确地以 `-1` 表示无效范围。
* **Tests**
  * 新增了极端溢出场景下标签页显示行为的测试，确保所有标签正确转移至下拉菜单。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->