### PR TITLE
chore(a11y): support middle mouse button to close (#860)

### DIFF
--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -315,6 +315,38 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
     setFocusKey(newKey);
   };
 
+  const handleRemoveTab = (removalTabKey: string, e: React.MouseEvent | React.KeyboardEvent) => {
+    const removeIndex = enabledTabs.indexOf(removalTabKey);
+    const removeTab = tabs.find(tab => tab.key === removalTabKey);
+    const removable = getRemovable(
+      removeTab?.closable,
+      removeTab?.closeIcon,
+      editable,
+      removeTab?.disabled,
+    );
+
+    if (removable) {
+      e.preventDefault();
+      e.stopPropagation();
+      editable.onEdit('remove', { key: removalTabKey, event: e });
+
+      // when remove last tab, focus previous tab
+      if (removeIndex === enabledTabs.length - 1) {
+        onOffset(-1);
+      } else {
+        onOffset(1);
+      }
+    }
+  };
+
+  const handleMouseDown = (key: string, e: React.MouseEvent) => {
+    setIsMouse(true);
+    // Middle mouse button
+    if (e.button === 1) {
+      handleRemoveTab(key, e);
+    }
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     const { code } = e;
 
@@ -381,25 +413,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
       // Backspace
       case 'Backspace':
       case 'Delete': {
-        const removeIndex = enabledTabs.indexOf(focusKey);
-        const removeTab = tabs.find(tab => tab.key === focusKey);
-        const removable = getRemovable(
-          removeTab?.closable,
-          removeTab?.closeIcon,
-          editable,
-          removeTab?.disabled,
-        );
-        if (removable) {
-          e.preventDefault();
-          e.stopPropagation();
-          editable.onEdit('remove', { key: focusKey, event: e });
-          // when remove last tab, focus previous tab
-          if (removeIndex === enabledTabs.length - 1) {
-            onOffset(-1);
-          } else {
-            onOffset(1);
-          }
-        }
+        handleRemoveTab(focusKey, e);
         break;
       }
     }
@@ -454,9 +468,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
         onBlur={() => {
           setFocusKey(undefined);
         }}
-        onMouseDown={() => {
-          setIsMouse(true);
-        }}
+        onMouseDown={e => handleMouseDown(key, e)}
         onMouseUp={() => {
           setIsMouse(false);
         }}

--- a/tests/accessibility.test.tsx
+++ b/tests/accessibility.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import type { TabsProps } from '../src';
@@ -291,5 +291,45 @@ describe('Tabs.Accessibility', () => {
     await user.tab();
     await user.tab();
     expect(tabPanel).not.toHaveFocus();
+  });
+
+  it('should close tab on middle mouse button click', async () => {
+    const Demo = () => {
+      const [items, setItems] = React.useState(
+        Array.from({ length: 3 }, (_, i) => ({
+          key: `${i + 1}`,
+          label: `Tab${i + 1}`,
+          children: `Content ${i + 1}`,
+        })),
+      );
+      return (
+        <Tabs
+          defaultActiveKey="1"
+          items={items}
+          editable={{
+            onEdit: (type, { key }) => {
+              if (type === 'remove') {
+                setItems(prevItems => prevItems.filter(item => item.key !== key));
+              }
+            },
+          }}
+        />
+      );
+    };
+
+    const { queryByRole } = render(<Demo />);
+
+    // Get the second tab
+    const secondTab = queryByRole('tab', { name: /Tab2/i });
+    expect(secondTab).toBeInTheDocument();
+
+    // Simulate middle mouse button click (button index 1)
+    fireEvent.mouseDown(secondTab, { button: 1 });
+
+    expect(queryByRole('tab', { name: /Tab2/i })).toBeNull();
+
+    // First and third tabs should still be there
+    expect(queryByRole('tab', { name: /Tab1/i })).toBeInTheDocument();
+    expect(queryByRole('tab', { name: /Tab3/i })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
* chore(a11y): support middle mouse button to close

* chore: add unit test

(cherry picked from commit 4f6a2e3853ab384a9d6c157f65206437e0abbfe1)

# Conflicts:
#	tests/accessibility.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 现在支持通过鼠标中键点击关闭标签页。

* **测试**
  * 增加了针对中键关闭标签页功能的测试用例，确保可用性和无障碍体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->