### PR TITLE
feat: add a remove button element for semantic

### DIFF
--- a/src/TabNavList/OperationNode.tsx
+++ b/src/TabNavList/OperationNode.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import type { EditableConfig, Tab, TabsLocale, MoreProps } from '../interface';
 import { getRemovable } from '../util';
 import AddButton from './AddButton';
+import { SemanticName } from '../Tabs';
 
 export interface OperationNodeProps {
   prefixCls: string;
@@ -27,6 +28,8 @@ export interface OperationNodeProps {
   getPopupContainer?: (node: HTMLElement) => HTMLElement;
   popupClassName?: string;
   popupStyle?: React.CSSProperties;
+  styles?: Pick<Partial<Record<SemanticName, React.CSSProperties>>, 'close'>;
+  classNames?: Pick<Partial<Record<SemanticName, string>>, 'close'>;
 }
 
 const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((props, ref) => {
@@ -47,6 +50,8 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
     getPopupContainer,
     popupClassName,
     popupStyle,
+    classNames,
+    styles,
   } = props;
   // ======================== Dropdown ========================
   const [open, setOpen] = useState(false);
@@ -98,7 +103,8 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
                 type="button"
                 aria-label={removeAriaLabel || 'remove'}
                 tabIndex={0}
-                className={`${dropdownPrefix}-menu-item-remove`}
+                className={clsx(`${dropdownPrefix}-menu-item-remove`, classNames?.close)}
+                style={styles?.close}
                 onClick={e => {
                   e.stopPropagation();
                   onRemoveTab(e, key);

--- a/src/TabNavList/OperationNode.tsx
+++ b/src/TabNavList/OperationNode.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 import type { EditableConfig, Tab, TabsLocale, MoreProps } from '../interface';
 import { getRemovable } from '../util';
 import AddButton from './AddButton';
-import { SemanticName } from '../Tabs';
+import type { SemanticName } from '../Tabs';
 
 export interface OperationNodeProps {
   prefixCls: string;

--- a/src/TabNavList/OperationNode.tsx
+++ b/src/TabNavList/OperationNode.tsx
@@ -28,8 +28,8 @@ export interface OperationNodeProps {
   getPopupContainer?: (node: HTMLElement) => HTMLElement;
   popupClassName?: string;
   popupStyle?: React.CSSProperties;
-  styles?: Pick<Partial<Record<SemanticName, React.CSSProperties>>, 'close'>;
-  classNames?: Pick<Partial<Record<SemanticName, string>>, 'close'>;
+  styles?: Pick<Partial<Record<SemanticName, React.CSSProperties>>, 'remove'>;
+  classNames?: Pick<Partial<Record<SemanticName, string>>, 'remove'>;
 }
 
 const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((props, ref) => {
@@ -103,8 +103,8 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
                 type="button"
                 aria-label={removeAriaLabel || 'remove'}
                 tabIndex={0}
-                className={clsx(`${dropdownPrefix}-menu-item-remove`, classNames?.close)}
-                style={styles?.close}
+                className={clsx(`${dropdownPrefix}-menu-item-remove`, classNames?.remove)}
+                style={styles?.remove}
                 onClick={e => {
                   e.stopPropagation();
                   onRemoveTab(e, key);

--- a/src/TabNavList/TabNode.tsx
+++ b/src/TabNavList/TabNode.tsx
@@ -24,8 +24,8 @@ export interface TabNodeProps {
   onMouseUp: React.MouseEventHandler;
   onFocus: React.FocusEventHandler;
   onBlur: React.FocusEventHandler;
-  styles?: Pick<Partial<Record<SemanticName, React.CSSProperties>>, 'item' | 'close'>;
-  classNames?: Pick<Partial<Record<SemanticName, string>>, 'item' | 'close'>;
+  styles?: Pick<Partial<Record<SemanticName, React.CSSProperties>>, 'item' | 'remove'>;
+  classNames?: Pick<Partial<Record<SemanticName, string>>, 'item' | 'remove'>;
 }
 
 const TabNode: React.FC<TabNodeProps> = props => {
@@ -131,8 +131,8 @@ const TabNode: React.FC<TabNodeProps> = props => {
           type="button"
           aria-label={removeAriaLabel || 'remove'}
           tabIndex={active ? 0 : -1}
-          className={clsx(`${tabPrefix}-remove`, tabNodeClassNames?.close)}
-          style={styles?.close}
+          className={clsx(`${tabPrefix}-remove`, tabNodeClassNames?.remove)}
+          style={styles?.remove}
           onClick={e => {
             e.stopPropagation();
             onRemoveTab(e);

--- a/src/TabNavList/TabNode.tsx
+++ b/src/TabNavList/TabNode.tsx
@@ -24,8 +24,8 @@ export interface TabNodeProps {
   onMouseUp: React.MouseEventHandler;
   onFocus: React.FocusEventHandler;
   onBlur: React.FocusEventHandler;
-  styles?: Pick<Record<SemanticName, React.CSSProperties>, 'item' | 'close'>;
-  classNames?: Pick<Record<SemanticName, string>, 'item' | 'close'>;
+  styles?: Pick<Partial<Record<SemanticName, React.CSSProperties>>, 'item' | 'close'>;
+  classNames?: Pick<Partial<Record<SemanticName, string>>, 'item' | 'close'>;
 }
 
 const TabNode: React.FC<TabNodeProps> = props => {

--- a/src/TabNavList/TabNode.tsx
+++ b/src/TabNavList/TabNode.tsx
@@ -2,6 +2,7 @@ import { clsx } from 'clsx';
 import * as React from 'react';
 import type { EditableConfig, Tab } from '../interface';
 import { genDataNodeKey, getRemovable } from '../util';
+import type { SemanticName } from '@/Tabs';
 
 export interface TabNodeProps {
   id: string;
@@ -23,8 +24,8 @@ export interface TabNodeProps {
   onMouseUp: React.MouseEventHandler;
   onFocus: React.FocusEventHandler;
   onBlur: React.FocusEventHandler;
-  style?: React.CSSProperties;
-  className?: string;
+  styles?: Pick<Record<SemanticName, React.CSSProperties>, 'item' | 'close'>;
+  classNames?: Pick<Record<SemanticName, string>, 'item' | 'close'>;
 }
 
 const TabNode: React.FC<TabNodeProps> = props => {
@@ -44,8 +45,8 @@ const TabNode: React.FC<TabNodeProps> = props => {
     onKeyDown,
     onMouseDown,
     onMouseUp,
-    style,
-    className,
+    styles,
+    classNames: tabNodeClassNames,
     tabCount,
     currentPosition,
   } = props;
@@ -83,13 +84,13 @@ const TabNode: React.FC<TabNodeProps> = props => {
     <div
       key={key}
       data-node-key={genDataNodeKey(key)}
-      className={clsx(tabPrefix, className, {
+      className={clsx(tabPrefix, tabNodeClassNames?.item, {
         [`${tabPrefix}-with-remove`]: removable,
         [`${tabPrefix}-active`]: active,
         [`${tabPrefix}-disabled`]: disabled,
         [`${tabPrefix}-focus`]: focus,
       })}
-      style={style}
+      style={styles?.item}
       onClick={onInternalClick}
     >
       {/* Primary Tab Button */}
@@ -130,7 +131,8 @@ const TabNode: React.FC<TabNodeProps> = props => {
           type="button"
           aria-label={removeAriaLabel || 'remove'}
           tabIndex={active ? 0 : -1}
-          className={`${tabPrefix}-remove`}
+          className={clsx(`${tabPrefix}-remove`, tabNodeClassNames?.close)}
+          style={styles?.close}
           onClick={e => {
             e.stopPropagation();
             onRemoveTab(e);

--- a/src/TabNavList/TabNode.tsx
+++ b/src/TabNavList/TabNode.tsx
@@ -2,7 +2,7 @@ import { clsx } from 'clsx';
 import * as React from 'react';
 import type { EditableConfig, Tab } from '../interface';
 import { genDataNodeKey, getRemovable } from '../util';
-import type { SemanticName } from '@/Tabs';
+import type { SemanticName } from '../Tabs';
 
 export interface TabNodeProps {
   id: string;

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -437,12 +437,12 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
         tab={tab}
         classNames={{
           item: tabsClassNames?.item,
-          close: tabsClassNames?.close,
+          remove: tabsClassNames?.remove,
         }}
         styles={{
           /* first node should not have margin left */
           item: i === 0 ? styles?.item : { ...tabNodeStyle, ...styles?.item },
-          close: styles?.close,
+          remove: styles?.remove,
         }}
         closable={tab.closable}
         editable={editable}

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -435,9 +435,15 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
         prefixCls={prefixCls}
         key={key}
         tab={tab}
-        className={tabsClassNames?.item}
-        /* first node should not have margin left */
-        style={i === 0 ? styles?.item : { ...tabNodeStyle, ...styles?.item }}
+        classNames={{
+          item: tabsClassNames?.item,
+          close: tabsClassNames?.close,
+        }}
+        styles={{
+          /* first node should not have margin left */
+          item: i === 0 ? styles?.item : { ...tabNodeStyle, ...styles?.item },
+          close: styles?.close,
+        }}
         closable={tab.closable}
         editable={editable}
         active={key === activeKey}

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -35,7 +35,7 @@ import type {
 // Used for accessibility
 let uuid = 0;
 
-export type SemanticName = 'popup' | 'item' | 'indicator' | 'content' | 'header';
+export type SemanticName = 'popup' | 'item' | 'indicator' | 'content' | 'header' | 'close';
 
 export interface TabsProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'children'> {

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -35,7 +35,7 @@ import type {
 // Used for accessibility
 let uuid = 0;
 
-export type SemanticName = 'popup' | 'item' | 'indicator' | 'content' | 'header' | 'close';
+export type SemanticName = 'popup' | 'item' | 'indicator' | 'content' | 'header' | 'remove';
 
 export interface TabsProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'children'> {

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -776,7 +776,7 @@ describe('Tabs.Basic', () => {
     expect(header).toHaveStyle({ background: 'yellow' });
   });
 
-  it('support classnames and styles for editable', () => {
+  it('support classnames and styles for editable close button', () => {
     const customClassNames = {
       close: 'custom-close',
     };
@@ -785,17 +785,30 @@ describe('Tabs.Basic', () => {
     };
 
     const { container } = render(
-      <Tabs
-        editable={{
-          onEdit: () => {},
-        }}
-        tabPosition="left"
-        items={[{ key: 'test', label: 'test', icon: 'test' }]}
-        styles={customStyles}
-        classNames={customClassNames}
-      />,
+      <div style={{ width: 100 }}>
+        <Tabs
+          editable={{
+            onEdit: () => {},
+          }}
+          tabPosition="left"
+          items={Array.from({ length: 10 }).map((_, index) => ({
+            key: `test-${index}`,
+            label: `test-${index}`,
+            icon: 'test',
+          }))}
+          styles={customStyles}
+          classNames={customClassNames}
+          getPopupContainer={() => document.querySelector('.rc-tabs') as HTMLElement}
+        />
+      </div>,
     );
 
+    expect(container.querySelector('.rc-tabs-dropdown-menu-item-remove')).toHaveClass(
+      'custom-close',
+    );
+    expect(container.querySelector('.rc-tabs-dropdown-menu-item-remove')).toHaveStyle({
+      background: 'red',
+    });
     expect(container.querySelector('.rc-tabs-tab-remove')).toHaveClass('custom-close');
     expect(container.querySelector('.rc-tabs-tab-remove')).toHaveStyle({ background: 'red' });
   });

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -798,17 +798,10 @@ describe('Tabs.Basic', () => {
           }))}
           styles={customStyles}
           classNames={customClassNames}
-          getPopupContainer={() => document.querySelector('.rc-tabs') as HTMLElement}
         />
       </div>,
     );
 
-    expect(container.querySelector('.rc-tabs-dropdown-menu-item-remove')).toHaveClass(
-      'custom-close',
-    );
-    expect(container.querySelector('.rc-tabs-dropdown-menu-item-remove')).toHaveStyle({
-      background: 'red',
-    });
     expect(container.querySelector('.rc-tabs-tab-remove')).toHaveClass('custom-close');
     expect(container.querySelector('.rc-tabs-tab-remove')).toHaveStyle({ background: 'red' });
   });

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -775,4 +775,28 @@ describe('Tabs.Basic', () => {
     expect(content).toHaveStyle({ background: 'green' });
     expect(header).toHaveStyle({ background: 'yellow' });
   });
+
+  it('support classnames and styles for editable', () => {
+    const customClassNames = {
+      close: 'custom-close',
+    };
+    const customStyles = {
+      close: { background: 'red' },
+    };
+
+    const { container } = render(
+      <Tabs
+        editable={{
+          onEdit: () => {},
+        }}
+        tabPosition="left"
+        items={[{ key: 'test', label: 'test', icon: 'test' }]}
+        styles={customStyles}
+        classNames={customClassNames}
+      />,
+    );
+
+    expect(container.querySelector('.rc-tabs-tab-remove')).toHaveClass('custom-close');
+    expect(container.querySelector('.rc-tabs-tab-remove')).toHaveStyle({ background: 'red' });
+  });
 });

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -776,12 +776,12 @@ describe('Tabs.Basic', () => {
     expect(header).toHaveStyle({ background: 'yellow' });
   });
 
-  it('support classnames and styles for editable close button', () => {
+  it('support classnames and styles for editable remove button', () => {
     const customClassNames = {
-      close: 'custom-close',
+      remove: 'custom-remove',
     };
     const customStyles = {
-      close: { background: 'red' },
+      remove: { background: 'red' },
     };
 
     const { container } = render(
@@ -802,7 +802,7 @@ describe('Tabs.Basic', () => {
       </div>,
     );
 
-    expect(container.querySelector('.rc-tabs-tab-remove')).toHaveClass('custom-close');
+    expect(container.querySelector('.rc-tabs-tab-remove')).toHaveClass('custom-remove');
     expect(container.querySelector('.rc-tabs-tab-remove')).toHaveStyle({ background: 'red' });
   });
 });

--- a/tests/overflow.test.tsx
+++ b/tests/overflow.test.tsx
@@ -528,13 +528,13 @@ describe('Tabs.Overflow', () => {
     expect(document.querySelector('.rc-tabs-dropdown')).toHaveStyle('color: red');
   });
 
-  it('should support classnames and styles for editable close button', () => {
+  it('should support classnames and styles for editable remove button', () => {
     jest.useFakeTimers();
     const { container } = render(
       getTabs({
         editable: { onEdit: () => {} },
-        classNames: { close: 'custom-close' },
-        styles: { close: { color: 'red' } },
+        classNames: { remove: 'custom-remove' },
+        styles: { remove: { color: 'red' } },
       }),
     );
 
@@ -548,7 +548,7 @@ describe('Tabs.Overflow', () => {
       jest.runAllTimers();
     });
     expect(document.querySelector('.rc-tabs-dropdown-menu-item-remove')).toHaveClass(
-      'custom-close',
+      'custom-remove',
     );
     expect(document.querySelector('.rc-tabs-dropdown-menu-item-remove')).toHaveStyle({
       color: 'red',

--- a/tests/overflow.test.tsx
+++ b/tests/overflow.test.tsx
@@ -528,6 +528,33 @@ describe('Tabs.Overflow', () => {
     expect(document.querySelector('.rc-tabs-dropdown')).toHaveStyle('color: red');
   });
 
+  it('should support classnames and styles for editable close button', () => {
+    jest.useFakeTimers();
+    const { container } = render(
+      getTabs({
+        editable: { onEdit: () => {} },
+        classNames: { close: 'custom-close' },
+        styles: { close: { color: 'red' } },
+      }),
+    );
+
+    triggerResize(container);
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    fireEvent.mouseEnter(container.querySelector('.rc-tabs-nav-more'));
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(document.querySelector('.rc-tabs-dropdown-menu-item-remove')).toHaveClass(
+      'custom-close',
+    );
+    expect(document.querySelector('.rc-tabs-dropdown-menu-item-remove')).toHaveStyle({
+      color: 'red',
+    });
+  });
+
   it('correct handle decimal', () => {
     hackOffsetInfo.container = 29;
     hackOffsetInfo.tabNodeList = 29;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 支持按语义键（如 item 与 remove）为标签项与关闭按钮分别配置 styles 与 classNames，便于更细粒度样式定制，覆盖标签列表、操作菜单与溢出项。

- 破坏性变更
  - 组件接口不再使用单一 style 与 className，需迁移到基于语义键的 styles 与 classNames（新增 remove 语义键）。

- 测试
  - 新增用例验证可编辑标签的关闭按钮在直接渲染与溢出菜单中均接受自定义类名与样式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->