### PR TITLE
Avoid rc package deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
     "@rc-component/menu": "~1.3.0",
     "@rc-component/motion": "^1.1.3",
     "@rc-component/resize-observer": "^1.0.0",
-    "@rc-component/util": "^1.3.0",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.0",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.3",
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "^16.0.1",

--- a/src/TabNavList/OperationNode.tsx
+++ b/src/TabNavList/OperationNode.tsx
@@ -1,7 +1,7 @@
 import { clsx } from 'clsx';
 import Dropdown from '@rc-component/dropdown';
 import Menu, { MenuItem } from '@rc-component/menu';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import type { EditableConfig, Tab, TabsLocale, MoreProps } from '../interface';

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -1,7 +1,6 @@
 import { clsx } from 'clsx';
 import ResizeObserver from '@rc-component/resize-observer';
-import useEvent from '@rc-component/util/lib/hooks/useEvent';
-import { useComposeRef } from '@rc-component/util/lib/ref';
+import { useComposeRef, useEvent } from '@rc-component/util';
 import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
 import TabContext from '../TabContext';

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -1,7 +1,6 @@
 // Accessibility https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tab_Role
 import { clsx } from 'clsx';
-import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
-import isMobile from '@rc-component/util/lib/isMobile';
+import { isMobile, useControlledState } from '@rc-component/util';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import TabContext from './TabContext';
@@ -37,8 +36,10 @@ let uuid = 0;
 
 export type SemanticName = 'popup' | 'item' | 'indicator' | 'content' | 'header' | 'remove';
 
-export interface TabsProps
-  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'children'> {
+export interface TabsProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'onChange' | 'children'
+> {
   prefixCls?: string;
   className?: string;
   style?: React.CSSProperties;

--- a/src/hooks/useAnimateConfig.ts
+++ b/src/hooks/useAnimateConfig.ts
@@ -1,4 +1,4 @@
-import warning from '@rc-component/util/lib/warning';
+import { warning } from '@rc-component/util';
 import type { TabsProps } from '..';
 import type { AnimatedConfig } from '../interface';
 

--- a/src/hooks/useIndicator.ts
+++ b/src/hooks/useIndicator.ts
@@ -1,4 +1,4 @@
-import raf from '@rc-component/util/lib/raf';
+import { raf } from '@rc-component/util';
 import React, { useEffect, useRef, useState } from 'react';
 import type { TabOffset } from '../interface';
 

--- a/src/hooks/useUpdate.ts
+++ b/src/hooks/useUpdate.ts
@@ -1,4 +1,4 @@
-import { useLayoutUpdateEffect } from '@rc-component/util/lib/hooks/useLayoutEffect';
+import { useLayoutUpdateEffect } from '@rc-component/util';
 import { useRef, useState } from 'react';
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export type {
   MoreProps,
   Tab,
   TabBarExtraContent,
+  TabBarExtraMap,
 } from './interface';
 export type { TabPaneProps } from './TabPanelList/TabPane';
 export type { GetIndicatorSize } from './hooks/useIndicator';

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ export type {
   MoreProps,
   Tab,
   TabBarExtraContent,
-  TabBarExtraMap,
 } from './interface';
 export type { TabPaneProps } from './TabPanelList/TabPane';
 export type { GetIndicatorSize } from './hooks/useIndicator';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,15 @@
 import type { TabsProps } from './Tabs';
 import Tabs from './Tabs';
 
+export type {
+  AnimatedConfig,
+  EditableConfig,
+  MoreProps,
+  Tab,
+  TabBarExtraContent,
+} from './interface';
+export type { TabPaneProps } from './TabPanelList/TabPane';
+export type { GetIndicatorSize } from './hooks/useIndicator';
 export type { TabsProps };
 
 export default Tabs;

--- a/tests/common/util.tsx
+++ b/tests/common/util.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-invalid-this */
 import { act } from '@testing-library/react';
-import { _rs as onEsResize } from '@rc-component/resize-observer/es/utils/observerUtil';
-import { _rs as onLibResize } from '@rc-component/resize-observer/lib/utils/observerUtil';
+import { _rs as onResize } from '@rc-component/resize-observer';
 import React from 'react';
 import Tabs from '../../src';
 import type { TabsProps } from '../../src/Tabs';
@@ -150,8 +149,7 @@ export const triggerResize = (container: Element) => {
   const target = container.querySelector('.rc-tabs-nav');
 
   act(() => {
-    onLibResize([{ target } as ResizeObserverEntry]);
-    onEsResize([{ target } as ResizeObserverEntry]);
+    onResize([{ target } as ResizeObserverEntry]);
   });
 };
 

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/dom';
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util';
 import React from 'react';
 import Tabs from '../src';
 import type { TabsProps } from '../src/Tabs';

--- a/tests/mobile.test.tsx
+++ b/tests/mobile.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import type { TabsProps } from '../src';

--- a/tests/operation-overflow.test.tsx
+++ b/tests/operation-overflow.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-invalid-this */
 import { render } from '@testing-library/react';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util';
 import { act } from 'react-dom/test-utils';
 import { getOffsetSizeFunc, getTabs, triggerResize } from './common/util';
 

--- a/tests/overflow.test.tsx
+++ b/tests/overflow.test.tsx
@@ -1,6 +1,5 @@
 import { act, fireEvent, render } from '@testing-library/react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { KeyCode, spyElementPrototypes } from '@rc-component/util';
 import React from 'react';
 import type { TabsProps } from '../src';
 import Tabs from '../src';

--- a/tests/rtl.test.tsx
+++ b/tests/rtl.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util';
 import { act } from 'react-dom/test-utils';
 import { getOffsetSizeFunc, getTabs, getTransformX, triggerResize } from './common/util';
 


### PR DESCRIPTION
## 变更内容

- 升级 @rc-component/father-plugin 和相关 rc 依赖版本。
- 将项目中对其他 rc 包 es/lib 构建产物的引用调整为包根入口。
- 补充 tabs 根入口中下游需要使用的类型导出。

## 验证

- 本次按已审核改动提交，未额外运行测试。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 更新依赖：将 `@rc-component/util` 升级至 1.11.1，@rc-component/father-plugin 升级至 2.2.0
  * 统一内部对工具库的导入来源以简化代码路径
* **New Features**
  * 扩展对外导出：新增多项类型导出（如 AnimatedConfig、EditableConfig、MoreProps、Tab、TabPaneProps、GetIndicatorSize 等），增强类型可用性

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/tabs/pull/990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->