### PR TITLE
chore(deps): bump @rc-component/menu to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@rc-component/dropdown": "~1.0.0",
-    "@rc-component/menu": "~1.4.0",
+    "@rc-component/menu": "~1.5.0",
     "@rc-component/motion": "^1.1.3",
     "@rc-component/resize-observer": "^1.0.0",
     "@rc-component/util": "^1.11.1",


### PR DESCRIPTION
Upgrade `@rc-component/menu` from `~1.4.0` to `~1.5.0` so Tabs uses the corrected menu ID generation logic.

This preserves the repository's existing semver range style and only changes the dependency declaration.

Validation:

- `ut run tsc`
- `ut run lint` (0 errors, 16 existing warnings)
- `ut test -- --runInBand` (74 tests passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **更新**
  * 升级菜单组件依赖版本，带来更好的兼容性与稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->