### PR TITLE
feat: support `scrollPosition` to align active tab on switch

### DIFF
--- a/docs/demo/scroll-position.md
+++ b/docs/demo/scroll-position.md
@@ -1,0 +1,8 @@
+---
+title: ScrollPosition
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/scroll-position.tsx"></code>

--- a/docs/examples/scroll-position.tsx
+++ b/docs/examples/scroll-position.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import Tabs from '@rc-component/tabs';
+import type { TabsProps } from '@rc-component/tabs';
+import '../../assets/index.less';
+
+const items: TabsProps['items'] = [];
+
+for (let i = 0; i < 12; i += 1) {
+  items.push({ key: String(i), label: `Tab ${i}`, children: `Content of ${i}` });
+}
+
+const positions: { label: string; value: TabsProps['scrollPosition'] }[] = [
+  { label: 'auto', value: 'auto' },
+  { label: 'start', value: 'start' },
+  { label: 'center', value: 'center' },
+  { label: 'end', value: 'end' },
+  { label: '0.25', value: 0.25 },
+];
+
+export default () => {
+  const [scrollPosition, setScrollPosition] = React.useState<TabsProps['scrollPosition']>('center');
+  const [direction, setDirection] = React.useState<TabsProps['direction']>('ltr');
+  const [tabPosition, setTabPosition] = React.useState<TabsProps['tabPosition']>('top');
+
+  return (
+    <div style={{ display: 'flex', gap: 24, minHeight: 320 }}>
+      <div style={{ minWidth: 260 }}>
+        <h3>scrollPosition</h3>
+        {positions.map(({ label, value }) => (
+          <label key={String(label)} style={{ display: 'block' }}>
+            <input
+              type="radio"
+              checked={scrollPosition === value}
+              onChange={() => setScrollPosition(value)}
+            />
+            {label}
+          </label>
+        ))}
+
+        <h3>direction</h3>
+        {(['ltr', 'rtl'] as const).map(d => (
+          <label key={d} style={{ display: 'block' }}>
+            <input type="radio" checked={direction === d} onChange={() => setDirection(d)} />
+            {d}
+          </label>
+        ))}
+
+        <h3>tabPosition</h3>
+        {(['top', 'bottom', 'left', 'right'] as const).map(p => (
+          <label key={p} style={{ display: 'block' }}>
+            <input type="radio" checked={tabPosition === p} onChange={() => setTabPosition(p)} />
+            {p}
+          </label>
+        ))}
+      </div>
+
+      <div style={{ flex: 1, maxWidth: 360 }} dir={direction}>
+        <Tabs
+          defaultActiveKey="6"
+          items={items}
+          scrollPosition={scrollPosition}
+          direction={direction}
+          tabPosition={tabPosition}
+          style={{ maxHeight: 160 }}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -17,6 +17,7 @@ import type {
   MoreProps,
   OnTabScroll,
   RenderTabBar,
+  ScrollPosition,
   SizeInfo,
   TabBarExtraContent,
   TabPosition,
@@ -54,6 +55,7 @@ export interface TabNavListProps {
     size?: GetIndicatorSize;
     align?: 'start' | 'center' | 'end';
   };
+  scrollPosition?: ScrollPosition;
   classNames?: Partial<Record<SemanticName, string>>;
   styles?: Partial<Record<SemanticName, React.CSSProperties>>;
 }
@@ -110,6 +112,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
     onTabClick,
     onTabScroll,
     indicator,
+    scrollPosition,
     classNames: tabsClassNames,
     styles,
   } = props;
@@ -264,12 +267,29 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
       top: 0,
     };
 
+    let ratio: number | null = null;
+    if (scrollPosition === 'start') {
+      ratio = 0;
+    } else if (scrollPosition === 'center') {
+      ratio = 0.5;
+    } else if (scrollPosition === 'end') {
+      ratio = 1;
+    } else if (typeof scrollPosition === 'number') {
+      ratio = Math.min(1, Math.max(0, scrollPosition));
+    }
+
     if (tabPositionTopOrBottom) {
       // ============ Align with top & bottom ============
       let newTransform = transformLeft;
 
+      if (ratio !== null) {
+        // Align the `ratio` point of the tab with the same point of the viewport.
+        newTransform = rtl
+          ? tabOffset.right + tabOffset.width * ratio - visibleTabContentValue * ratio
+          : -(tabOffset.left + tabOffset.width * ratio - visibleTabContentValue * ratio);
+      }
       // RTL
-      if (rtl) {
+      else if (rtl) {
         if (tabOffset.right < transformLeft) {
           newTransform = tabOffset.right;
         } else if (tabOffset.right + tabOffset.width > transformLeft + visibleTabContentValue) {
@@ -289,7 +309,9 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
       // ============ Align with left & right ============
       let newTransform = transformTop;
 
-      if (tabOffset.top < -transformTop) {
+      if (ratio !== null) {
+        newTransform = -(tabOffset.top + tabOffset.height * ratio - visibleTabContentValue * ratio);
+      } else if (tabOffset.top < -transformTop) {
         newTransform = -tabOffset.top;
       } else if (tabOffset.top + tabOffset.height > -transformTop + visibleTabContentValue) {
         newTransform = -(tabOffset.top + tabOffset.height - visibleTabContentValue);
@@ -550,6 +572,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
     scrollToTab();
   }, [
     activeKey,
+    scrollPosition,
     transformMin,
     transformMax,
     stringify(activeTabOffset),

--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -274,7 +274,7 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
       ratio = 0.5;
     } else if (scrollPosition === 'end') {
       ratio = 1;
-    } else if (typeof scrollPosition === 'number') {
+    } else if (typeof scrollPosition === 'number' && !Number.isNaN(scrollPosition)) {
       ratio = Math.min(1, Math.max(0, scrollPosition));
     }
 

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -19,6 +19,7 @@ import type {
   TabBarExtraContent,
   TabPosition,
   TabsLocale,
+  ScrollPosition,
 } from './interface';
 
 /**
@@ -35,13 +36,7 @@ import type {
 let uuid = 0;
 
 export type SemanticName =
-  | 'popup'
-  | 'item'
-  | 'indicator'
-  | 'body'
-  | 'content'
-  | 'header'
-  | 'remove';
+  'popup' | 'item' | 'indicator' | 'body' | 'content' | 'header' | 'remove';
 
 export interface TabsProps extends Omit<
   React.HTMLAttributes<HTMLDivElement>,
@@ -66,6 +61,7 @@ export interface TabsProps extends Omit<
   tabBarStyle?: React.CSSProperties;
   tabPosition?: TabPosition;
   destroyOnHidden?: boolean;
+  scrollPosition?: ScrollPosition;
 
   onChange?: (activeKey: string) => void;
   onTabClick?: (activeKey: string, e: React.KeyboardEvent | React.MouseEvent) => void;
@@ -112,6 +108,7 @@ const Tabs = React.forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
     getPopupContainer,
     popupClassName,
     indicator,
+    scrollPosition,
     classNames: tabsClassNames,
     styles,
     ...restProps
@@ -194,6 +191,7 @@ const Tabs = React.forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
     getPopupContainer,
     popupClassName: clsx(popupClassName, tabsClassNames?.popup),
     indicator,
+    scrollPosition,
     styles,
     classNames: tabsClassNames,
   };

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -46,6 +46,8 @@ export type TabOffsetMap = Map<React.Key, TabOffset>;
 
 export type TabPosition = 'left' | 'right' | 'top' | 'bottom';
 
+export type ScrollPosition = 'auto' | 'start' | 'center' | 'end' | number;
+
 type RenderTabBarProps = {
   id: string;
   activeKey: string;

--- a/tests/overflow.test.tsx
+++ b/tests/overflow.test.tsx
@@ -319,10 +319,6 @@ describe('Tabs.Overflow', () => {
     });
 
     describe('scrollPosition', () => {
-      // Mock layout: container=50, extra=10*2, tab=20, add=10, more=10.
-      // `disabled` is the 4th tab (offset=60, size=20) and the viewport is 40px,
-      // so start=-60 / center=-50 / end=-40 for both top/bottom and left/right.
-      // Numeric ratios are clamped to [0, 1]: 1.5 → end (-40), -0.5 → start (-60).
       const layouts: { position: any; expected: number }[] = [
         { position: 'auto' as const, expected: -40 },
         { position: 'start' as const, expected: -60 },
@@ -333,6 +329,7 @@ describe('Tabs.Overflow', () => {
         { position: 1 as const, expected: -40 },
         { position: 1.5 as const, expected: -40 },
         { position: -0.5 as const, expected: -60 },
+        { position: Number.NaN, expected: -40 },
       ];
 
       it.each(layouts)('top: $position', ({ position, expected }) => {

--- a/tests/overflow.test.tsx
+++ b/tests/overflow.test.tsx
@@ -319,13 +319,20 @@ describe('Tabs.Overflow', () => {
     });
 
     describe('scrollPosition', () => {
+      // Mock layout: container=50, extra=10*2, tab=20, add=10, more=10.
+      // `disabled` is the 4th tab (offset=60, size=20) and the viewport is 40px,
+      // so start=-60 / center=-50 / end=-40 for both top/bottom and left/right.
+      // Numeric ratios are clamped to [0, 1]: 1.5 → end (-40), -0.5 → start (-60).
       const layouts: { position: any; expected: number }[] = [
         { position: 'auto' as const, expected: -40 },
         { position: 'start' as const, expected: -60 },
         { position: 'center' as const, expected: -50 },
         { position: 'end' as const, expected: -40 },
-        { position: 1 as const, expected: -40 },
+        { position: 0.25 as const, expected: -55 },
         { position: 0.5 as const, expected: -50 },
+        { position: 1 as const, expected: -40 },
+        { position: 1.5 as const, expected: -40 },
+        { position: -0.5 as const, expected: -60 },
       ];
 
       it.each(layouts)('top: $position', ({ position, expected }) => {
@@ -339,17 +346,16 @@ describe('Tabs.Overflow', () => {
         jest.useRealTimers();
       });
 
-      it('keeps center between start and end for left tabPosition', () => {
+      it.each(layouts)('left: $position', ({ position, expected }) => {
         jest.useFakeTimers();
         const { container } = render(
-          getTabs({ activeKey: 'disabled', tabPosition: 'left', scrollPosition: 'center' }),
+          getTabs({ activeKey: 'disabled', tabPosition: 'left', scrollPosition: position }),
         );
         triggerResize(container);
         act(() => {
           jest.runAllTimers();
         });
-        // Same geometry as the top case: disabled top=60, height=20, viewport=40.
-        expect(getTransformY(container)).toEqual(-50);
+        expect(getTransformY(container)).toEqual(expected);
         jest.useRealTimers();
       });
     });

--- a/tests/overflow.test.tsx
+++ b/tests/overflow.test.tsx
@@ -318,6 +318,42 @@ describe('Tabs.Overflow', () => {
       jest.useRealTimers();
     });
 
+    describe('scrollPosition', () => {
+      const layouts: { position: any; expected: number }[] = [
+        { position: 'auto' as const, expected: -40 },
+        { position: 'start' as const, expected: -60 },
+        { position: 'center' as const, expected: -50 },
+        { position: 'end' as const, expected: -40 },
+        { position: 1 as const, expected: -40 },
+        { position: 0.5 as const, expected: -50 },
+      ];
+
+      it.each(layouts)('top: $position', ({ position, expected }) => {
+        jest.useFakeTimers();
+        const { container } = render(getTabs({ activeKey: 'disabled', scrollPosition: position }));
+        triggerResize(container);
+        act(() => {
+          jest.runAllTimers();
+        });
+        expect(getTransformX(container)).toEqual(expected);
+        jest.useRealTimers();
+      });
+
+      it('keeps center between start and end for left tabPosition', () => {
+        jest.useFakeTimers();
+        const { container } = render(
+          getTabs({ activeKey: 'disabled', tabPosition: 'left', scrollPosition: 'center' }),
+        );
+        triggerResize(container);
+        act(() => {
+          jest.runAllTimers();
+        });
+        // Same geometry as the top case: disabled top=60, height=20, viewport=40.
+        expect(getTransformY(container)).toEqual(-50);
+        jest.useRealTimers();
+      });
+    });
+
     it('left', () => {
       jest.useFakeTimers();
       const onTabScroll = jest.fn();

--- a/tests/rtl.test.tsx
+++ b/tests/rtl.test.tsx
@@ -66,4 +66,33 @@ describe('Tabs.RTL', () => {
 
     jest.useRealTimers();
   });
+
+  // RTL mirrors LTR: `disabled` sits at right=60/width=20 with a 40px viewport,
+  // so start=60 / center=50 / end=40. Ratios clamp to [0,1]: 1.5 → end, -0.5 → start.
+  describe('scrollPosition', () => {
+    const layouts: { position: any; expected: number }[] = [
+      { position: 'auto' as const, expected: 40 },
+      { position: 'start' as const, expected: 60 },
+      { position: 'center' as const, expected: 50 },
+      { position: 'end' as const, expected: 40 },
+      { position: 0.25 as const, expected: 55 },
+      { position: 0.5 as const, expected: 50 },
+      { position: 1 as const, expected: 40 },
+      { position: 1.5 as const, expected: 40 },
+      { position: -0.5 as const, expected: 60 },
+    ];
+
+    it.each(layouts)('rtl: $position', ({ position, expected }) => {
+      jest.useFakeTimers();
+      const { container } = render(
+        getTabs({ direction: 'rtl', defaultActiveKey: 'disabled', scrollPosition: position }),
+      );
+      triggerResize(container);
+      act(() => {
+        jest.runAllTimers();
+      });
+      expect(getTransformX(container)).toEqual(expected);
+      jest.useRealTimers();
+    });
+  });
 });

--- a/tests/rtl.test.tsx
+++ b/tests/rtl.test.tsx
@@ -67,8 +67,6 @@ describe('Tabs.RTL', () => {
     jest.useRealTimers();
   });
 
-  // RTL mirrors LTR: `disabled` sits at right=60/width=20 with a 40px viewport,
-  // so start=60 / center=50 / end=40. Ratios clamp to [0,1]: 1.5 → end, -0.5 → start.
   describe('scrollPosition', () => {
     const layouts: { position: any; expected: number }[] = [
       { position: 'auto' as const, expected: 40 },
@@ -80,6 +78,7 @@ describe('Tabs.RTL', () => {
       { position: 1 as const, expected: 40 },
       { position: 1.5 as const, expected: 40 },
       { position: -0.5 as const, expected: 60 },
+      { position: Number.NaN, expected: 40 },
     ];
 
     it.each(layouts)('rtl: $position', ({ position, expected }) => {


### PR DESCRIPTION
## 背景

对应 ant-design/ant-design#39433。

该 issue 希望能在标签页溢出滚动时,控制选中(activated)tab 的滚动对齐位置——尤其在移动端,用户期望切换时让选中标签**居中**显示,而不是仅当它移出视口时才勉强滚入并对齐到最近的边缘。当前实现是:仅当 active tab 超出视口时才滚动,且对齐到最近的边缘。

## 本 PR 做了什么

新增 \`scrollPosition\` 属性:

\`\`\`ts
type ScrollPosition = 'auto' | 'start' | 'center' | 'end' | number;
\`\`\`

- \`'auto'\`(默认):保留旧行为——仅在 active tab 超出视口时滚动,并对齐到边缘。
- \`'start'\` / \`'center'\` / \`'end'\`:将 active tab 的对应点(start/center/end)与视口的同一对齐点重合。
- \`number\`:对齐比例,取值 \`0\`(start)到 \`1\`(end);\`0.5\` 等价于 \`center\`。

\`\`\`tsx
<Tabs scrollPosition="center" items={items} />
\`\`\`

### 实现

在 \`scrollToTab\` 中,将字符串/\`number\` 解析为 \`ratio\`(\`'auto'\` 时为 \`null\`)。当存在 ratio 时,计算一个让 tab 的 \`ratio\` 点与视口同一 \`ratio\` 点对齐的 transform,再通过既有的 \`alignInRange\` 进行夹取。兼容 LTR/RTL(top/bottom)以及 left/right 两种 \`tabPosition\`。

### 类型导出

\`ScrollPosition\` 定义在 \`interface.ts\`,但**未**从包入口单独 re-export——与 \`TabPosition\` 等其它叶子联合类型保持一致。使用方应通过 \`TabsProps['scrollPosition']\` 获取,demo 示例亦是如此。

## 测试

在 \`tests/overflow.test.tsx\` 中新增 \`scrollPosition\` describe 块,覆盖 \`auto\`/\`start\`/\`center\`/\`end\`/数值比例(\`tabPosition: 'top'\`),以及 \`center\` 在 \`tabPosition: 'left'\` 下的场景。\`overflow.test.tsx\` 全部通过(28 passed)。

## Demo

新增 \`scroll-position\` 示例,注册于 \`docs/demo/scroll-position.md\`,提供 \`scrollPosition\`、\`direction\`(ltr/rtl)、\`tabPosition\`(top/bottom/left/right)的切换。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * Tabs 新增 `scrollPosition` 配置，支持将当前标签定位到起始、居中、末尾或指定比例位置。
  * 支持水平、垂直及 RTL 布局，并在配置变化时自动更新定位。
  * 数值定位会自动限制在 0 到 1 范围内，并安全处理无效数值。
* **文档**
  * 新增滚动定位示例页面，展示不同方向、标签位置和定位方式的交互效果。
* **测试**
  * 补充溢出滚动、数值边界及 RTL 布局下的定位测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->