### PR TITLE
fix: preserve numeric zero tab content

### DIFF
--- a/src/TabNavList/ExtraContent.tsx
+++ b/src/TabNavList/ExtraContent.tsx
@@ -9,7 +9,7 @@ interface ExtraContentProps {
 
 const ExtraContent = React.forwardRef<HTMLDivElement, ExtraContentProps>((props, ref) => {
   const { position, prefixCls, extra } = props;
-  if (!extra) {
+  if (!extra && extra !== 0) {
     return null;
   }
 
@@ -31,7 +31,7 @@ const ExtraContent = React.forwardRef<HTMLDivElement, ExtraContentProps>((props,
     content = assertExtra.left;
   }
 
-  return content ? (
+  return content || content === 0 ? (
     <div className={`${prefixCls}-extra-content`} ref={ref}>
       {content}
     </div>

--- a/src/TabNavList/TabNode.tsx
+++ b/src/TabNavList/TabNode.tsx
@@ -53,6 +53,7 @@ const TabNode: React.FC<TabNodeProps> = props => {
   const tabPrefix = `${prefixCls}-tab`;
 
   const removable = getRemovable(closable, closeIcon, editable, disabled);
+  const hasIcon = !!icon || icon === 0;
 
   function onInternalClick(e: React.MouseEvent | React.KeyboardEvent) {
     if (disabled) {
@@ -68,8 +69,8 @@ const TabNode: React.FC<TabNodeProps> = props => {
   }
 
   const labelNode = React.useMemo<React.ReactNode>(
-    () => (icon && typeof label === 'string' ? <span>{label}</span> : label),
-    [label, icon],
+    () => (hasIcon && typeof label === 'string' ? <span>{label}</span> : label),
+    [label, hasIcon],
   );
 
   const btnRef = React.useRef<HTMLDivElement>(null);
@@ -121,7 +122,7 @@ const TabNode: React.FC<TabNodeProps> = props => {
             {`Tab ${currentPosition} of ${tabCount}`}
           </div>
         )}
-        {icon && <span className={`${tabPrefix}-icon`}>{icon}</span>}
+        {hasIcon && <span className={`${tabPrefix}-icon`}>{icon}</span>}
         {label && labelNode}
       </div>
 

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -537,6 +537,17 @@ describe('Tabs.Basic', () => {
     );
   });
 
+  it('renders numeric zero extra content', () => {
+    const { container, rerender } = render(getTabs({ tabBarExtraContent: 0 }));
+    expect(container.querySelectorAll('.rc-tabs-extra-content')).toHaveLength(1);
+    expect(container.querySelector('.rc-tabs-extra-content')).toHaveTextContent('0');
+
+    rerender(getTabs({ tabBarExtraContent: { left: 0, right: 0 } }));
+    expect(container.querySelectorAll('.rc-tabs-extra-content')).toHaveLength(2);
+    expect(container.querySelectorAll('.rc-tabs-extra-content')[0]).toHaveTextContent('0');
+    expect(container.querySelectorAll('.rc-tabs-extra-content')[1]).toHaveTextContent('0');
+  });
+
   it('no break of empty object', () => {
     render(getTabs({ tabBarExtraContent: {} }));
   });

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -648,6 +648,21 @@ describe('Tabs.Basic', () => {
     expect(container.querySelectorAll<HTMLSpanElement>(selectors).length).toBe(1);
   });
 
+  it('renders numeric zero tab labels and icons', () => {
+    const { getAllByRole, container } = render(
+      <Tabs
+        items={[
+          { key: 'zero-label', label: 0, children: 'Zero label content' },
+          { key: 'zero-icon', label: 'Label', icon: 0, children: 'Zero icon content' },
+        ]}
+      />,
+    );
+
+    expect(getAllByRole('tab')[0]).toHaveTextContent('0');
+    expect(container.querySelector('.rc-tabs-tab-icon')).toHaveTextContent('0');
+    expect(getAllByRole('tab')[1].querySelectorAll('span')).toHaveLength(2);
+  });
+
   it('support indicatorAlign', async () => {
     const { container: startContainer, rerender: rerenderStart } = render(
       <Tabs


### PR DESCRIPTION
## Summary

- render numeric `0` passed as `tabBarExtraContent`
- support zero in both the direct ReactNode form and the `{ left, right }` map form
- preserve the icon wrapper and string-label layout when a tab uses `icon={0}`
- add regressions covering direct/left/right extras, a zero label, and a zero icon

## Problem

Tabs exposes several ReactNode content paths, but two truthiness boundaries in `ExtraContent` omitted numeric zero whether passed directly or assigned to `left`/`right`.

Tab labels already render zero because React renders the result of `0 && node`, but tab icons have a subtler inconsistency: `icon={0}` is emitted as a bare text node instead of the normal icon wrapper. It also bypasses the string-label wrapper used whenever an icon is present, so icon spacing/layout classes cannot apply consistently.

The fix distinguishes zero from the existing empty cases and uses one `hasIcon` predicate for both icon rendering and label layout. Behavior for `false`, empty strings, `null`, `undefined`, and an empty extra map remains unchanged.

## Validation

- exact-base extra regression failed because `0` rendered zero extra-content nodes
- the zero-icon regression failed because the icon wrapper was absent
- full Jest suite: 6 suites, 76 tests, and 3 snapshots passed
- TypeScript (`tsc --noEmit`)
- focused ESLint and Prettier checks
- ESM, CJS, declaration, and Less compilation
- `git diff --check`

I checked current open issues and every open PR file list. No open work changes `src/TabNavList/ExtraContent.tsx` or `src/TabNavList/TabNode.tsx` for numeric-zero content.

AI assistance disclosure: Codex was used to trace the render boundaries, audit open work, run the exact-base regressions, and draft this report. The behavior and validation are directly reproducible from this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复额外内容为数字 `0` 时无法正常显示的问题。
  * 修复标签或图标值为数字 `0` 时未正确渲染的问题。
  * 补充相关测试，确保数字 `0` 能在标签、图标及额外内容中正常显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->