### PR TITLE
fix: keep tab extras outside tablist ownership

### DIFF
--- a/src/TabNavList/index.tsx
+++ b/src/TabNavList/index.tsx
@@ -588,8 +588,6 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
     <ResizeObserver onResize={onListHolderResize}>
       <div
         ref={useComposeRef(ref, containerRef)}
-        role="tablist"
-        aria-orientation={tabPositionTopOrBottom ? 'horizontal' : 'vertical'}
         className={clsx(`${prefixCls}-nav`, className, tabsClassNames?.header)}
         style={{ ...styles?.header, ...style }}
         onKeyDown={() => {
@@ -612,6 +610,8 @@ const TabNavList = React.forwardRef<HTMLDivElement, TabNavListProps>((props, ref
             <ResizeObserver onResize={onListHolderResize}>
               <div
                 ref={tabListRef}
+                role="tablist"
+                aria-orientation={tabPositionTopOrBottom ? 'horizontal' : 'vertical'}
                 className={`${prefixCls}-nav-list`}
                 style={{
                   transform: `translate(${transformLeft}px, ${transformTop}px)`,

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -5,15 +5,15 @@ exports[`Tabs.Basic Normal 1`] = `
   class="rc-tabs rc-tabs-top"
 >
   <div
-    aria-orientation="horizontal"
     class="rc-tabs-nav"
-    role="tablist"
   >
     <div
       class="rc-tabs-nav-wrap rc-tabs-nav-wrap-ping-right"
     >
       <div
+        aria-orientation="horizontal"
         class="rc-tabs-nav-list"
+        role="tablist"
         style="transform: translate(0px, 0px);"
       >
         <div
@@ -108,15 +108,15 @@ exports[`Tabs.Basic Skip invalidate children 1`] = `
   class="rc-tabs rc-tabs-top"
 >
   <div
-    aria-orientation="horizontal"
     class="rc-tabs-nav"
-    role="tablist"
   >
     <div
       class="rc-tabs-nav-wrap"
     >
       <div
+        aria-orientation="horizontal"
         class="rc-tabs-nav-list"
+        role="tablist"
         style="transform: translate(0px, 0px);"
       >
         <div

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -537,6 +537,24 @@ describe('Tabs.Basic', () => {
     );
   });
 
+  it('keeps interactive extra content outside the tablist', () => {
+    const { container } = render(
+      getTabs({
+        tabBarExtraContent: {
+          left: <button type="button">Left action</button>,
+          right: <button type="button">Right action</button>,
+        },
+      }),
+    );
+    const tablist = container.querySelector('[role="tablist"]')!;
+
+    expect(tablist).toContainElement(container.querySelector('[role="tab"]'));
+    expect(container.querySelector('.rc-tabs-nav-more')!.closest('[role="tablist"]')).toBeNull();
+    screen.getAllByRole('button', { name: /action/ }).forEach(button => {
+      expect(button.closest('[role="tablist"]')).toBeNull();
+    });
+  });
+
   it('no break of empty object', () => {
     render(getTabs({ tabBarExtraContent: {} }));
   });


### PR DESCRIPTION
## Summary

- move `role="tablist"` and `aria-orientation` from the outer navigation container to the element that owns the tab nodes
- keep left/right `tabBarExtraContent`, the add control, and overflow operations visually unchanged but outside the tablist accessibility ownership
- add a regression covering interactive extra content on both sides and the overflow control

Fixes #1013.

## Why

The outer navigation element currently owns arbitrary `tabBarExtraContent`. When that content contains a button, accessibility tools report `aria-required-children` because a tablist should own tabs rather than unrelated interactive controls. The inner `-nav-list` already contains the tab nodes and remains the existing measurement/transform node, so moving only the ARIA role fixes ownership without changing layout or ref behavior.

## Validation

- `npm test -- --runInBand tests/index.test.tsx` — 75 tests and 3 snapshots passed across the repository test scopes selected by rc-test
- `npm run tsc`
- `npm run lint` — no errors; existing hook warnings remain
- `npx prettier --check src/TabNavList/index.tsx tests/index.test.tsx`
- `git diff --check HEAD^ HEAD`

AI assistance disclosure: Codex helped trace the accessibility ownership, implement the focused role move and regression, and run the checks. I reviewed the diff and results before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化标签页的无障碍语义结构，确保标签列表角色仅应用于实际的标签列表区域。
  * 修复标签栏中的额外交互内容和“更多”控件被错误包含在标签列表中的问题。

* **测试**
  * 新增测试，验证交互按钮和其他额外内容位于标签列表之外，同时标签页仍正确保留在列表中。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->