### PR TITLE
fix: wrap initial overflow ArrowUp to last tab

### DIFF
--- a/src/TabNavList/OperationNode.tsx
+++ b/src/TabNavList/OperationNode.tsx
@@ -128,8 +128,12 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
 
   function selectOffset(offset: -1 | 1) {
     const enabledTabs = tabs.filter(tab => !tab.disabled);
-    let selectedIndex = enabledTabs.findIndex(tab => tab.key === selectedKey) || 0;
+    let selectedIndex = enabledTabs.findIndex(tab => tab.key === selectedKey);
     const len = enabledTabs.length;
+
+    if (selectedIndex === -1 && offset === -1) {
+      selectedIndex = 0;
+    }
 
     for (let i = 0; i < len; i += 1) {
       selectedIndex = (selectedIndex + offset + len) % len;

--- a/tests/overflow.test.tsx
+++ b/tests/overflow.test.tsx
@@ -111,6 +111,35 @@ describe('Tabs.Overflow', () => {
     unmount();
   });
 
+  it('should select the last enabled tab on the first ArrowUp', () => {
+    jest.useFakeTimers();
+    const { container, unmount } = render(getTabs());
+
+    triggerResize(container);
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const moreButton = container.querySelector('.rc-tabs-nav-more');
+    fireEvent.keyDown(moreButton, {
+      which: KeyCode.DOWN,
+      keyCode: KeyCode.DOWN,
+      charCode: KeyCode.DOWN,
+    });
+    fireEvent.keyDown(moreButton, {
+      which: KeyCode.UP,
+      keyCode: KeyCode.UP,
+      charCode: KeyCode.UP,
+    });
+
+    expect(document.querySelector('li.rc-tabs-dropdown-menu-item-selected').textContent).toEqual(
+      'miu',
+    );
+
+    unmount();
+    jest.useRealTimers();
+  });
+
   [KeyCode.SPACE, KeyCode.ENTER].forEach(code => {
     it(`keyboard with select keycode: ${code}`, () => {
       jest.useFakeTimers();


### PR DESCRIPTION
## Summary\n\n- make the first ArrowUp press in the overflow menu wrap to the last enabled tab\n- preserve the existing first ArrowDown behavior\n- add a regression test with a disabled tab in the overflow sequence\n\n## Problem\n\nWhen the overflow menu opens, selectedKey is initially null. findIndex therefore returns -1. The existing modulo calculation works for ArrowDown (-1 + 1 -> 0), but ArrowUp advances from -1 to the second-to-last enabled tab instead of wrapping to the last one.\n\n## Validation\n\n- before the fix, the new test expected miu but selected cute\n- npm test -- tests/overflow.test.tsx --runInBand (22 tests)\n- npm test -- --runInBand (6 suites, 75 tests, 3 snapshots)\n- npm run tsc\n- npm run lint (0 errors; existing warnings only)\n- Prettier check and git diff --check\n\nAI assistance disclosure: Codex was used to trace the keyboard index calculation, add the regression test, run validation, and draft this description. I verified the reproduction, red/green result, diff, and test counts directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复下拉标签导航中使用向上箭头时的选中位置问题。
  * 当未选中任何标签时，向上导航现在会正确选中最后一个启用的标签。

* **测试**
  * 新增键盘导航测试，验证向下打开菜单后按向上箭头可选中最后一个启用的标签。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->