### PR TITLE
chore(deps): bump @rc-component/menu to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@rc-component/dropdown": "~1.0.0",
-    "@rc-component/menu": "~1.5.0",
+    "@rc-component/menu": "~1.6.0",
     "@rc-component/motion": "^1.1.3",
     "@rc-component/resize-observer": "^1.0.0",
     "@rc-component/util": "^1.11.1",


### PR DESCRIPTION
## Summary

- bump `@rc-component/menu` from `~1.5.0` to `~1.6.0`
- keep the runtime menu dependency aligned with the latest semantic API

## Testing

- `ut run tsc`
- `ut test -- --runInBand`
- `ut run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **更新**
  * 更新菜单组件依赖版本，带来兼容性与稳定性改进。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->