### PR TITLE
feat!: migrate more dropdown to open API

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ Then open `http://localhost:8000`.
 | --- | --- | --- | --- |
 | `icon` | ReactNode | - | The icon shown in the more trigger. |
 | `popupRender` | `(menu: ReactElement, info: { restTabs: Tab[], onClose: () => void }) => ReactElement` | - | Customize the dropdown popup content. The `info` object provides `restTabs` (all overflowed tabs) and `onClose` (function to close the dropdown). |
-| Other dropdown props | from DropdownProps | - | All other [rc-dropdown](https://github.com/react-component/dropdown) props such as `trigger`, `overlayClassName`, `visible`, etc. are also supported. |
+| Other dropdown props | from DropdownProps | - | All other [rc-dropdown](https://github.com/react-component/dropdown) props such as `trigger`, `overlayClassName`, `open`, etc. are also supported. |
+
+Dropdown 2 uses `more.open` and `more.onOpenChange`. The previous `more.visible` and `more.onVisibleChange` props are no longer supported and must be migrated when upgrading.
 
 ## Development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -108,7 +108,9 @@ npm start
 | --- | --- | --- | --- |
 | `icon` | ReactNode | - | 更多按钮的图标。 |
 | `popupRender` | `(menu: ReactElement, info: { restTabs: Tab[], onClose: () => void }) => ReactElement` | - | 自定义下拉弹层内容。`info` 对象提供 `restTabs`（所有溢出标签）和 `onClose`（关闭下拉菜单的函数）。 |
-| 其他下拉属性 | 来自 DropdownProps | - | 其他 [rc-dropdown](https://github.com/react-component/dropdown) 属性如 `trigger`、`overlayClassName`、`visible` 等也都支持。 |
+| 其他下拉属性 | 来自 DropdownProps | - | 其他 [rc-dropdown](https://github.com/react-component/dropdown) 属性如 `trigger`、`overlayClassName`、`open` 等也都支持。 |
+
+Dropdown 2 使用 `more.open` 和 `more.onOpenChange`。旧的 `more.visible` 和 `more.onVisibleChange` 已不再支持，升级时需要同步迁移。
 
 ## 本地开发
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@rc-component/dropdown": "~1.0.0",
+    "@rc-component/dropdown": "~2.0.0",
     "@rc-component/menu": "~1.6.0",
     "@rc-component/motion": "^1.1.3",
     "@rc-component/resize-observer": "^1.0.0",

--- a/src/TabNavList/OperationNode.tsx
+++ b/src/TabNavList/OperationNode.tsx
@@ -208,8 +208,8 @@ const OperationNode = React.forwardRef<HTMLDivElement, OperationNodeProps>((prop
     <Dropdown
       prefixCls={dropdownPrefix}
       overlay={overlay}
-      visible={tabs.length ? open : false}
-      onVisibleChange={setOpen}
+      open={tabs.length ? open : false}
+      onOpenChange={setOpen}
       overlayClassName={overlayClassName}
       overlayStyle={popupStyle}
       mouseEnterDelay={0.1}

--- a/tests/overflow.test.tsx
+++ b/tests/overflow.test.tsx
@@ -111,6 +111,32 @@ describe('Tabs.Overflow', () => {
     unmount();
   });
 
+  it('supports more.open and more.onOpenChange', () => {
+    jest.useFakeTimers();
+    const onOpenChange = jest.fn();
+    const dropdown = (open: boolean) => getTabs({ more: { open, onOpenChange, trigger: 'click' } });
+    const { container, rerender, unmount } = render(dropdown(false));
+    triggerResize(container);
+    act(() => {
+      jest.runAllTimers();
+    });
+    const button = container.querySelector('.rc-tabs-nav-more');
+    fireEvent.click(button);
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    expect(button).not.toHaveClass('rc-tabs-dropdown-open');
+
+    rerender(dropdown(true));
+    expect(button).toHaveClass('rc-tabs-dropdown-open');
+    fireEvent.click(button);
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+    expect(button).toHaveClass('rc-tabs-dropdown-open');
+
+    rerender(dropdown(false));
+    expect(button).not.toHaveClass('rc-tabs-dropdown-open');
+    unmount();
+    jest.useRealTimers();
+  });
+
   [KeyCode.SPACE, KeyCode.ENTER].forEach(code => {
     it(`keyboard with select keycode: ${code}`, () => {
       jest.useFakeTimers();


### PR DESCRIPTION
Dropdown 2.0 已移除 `visible`、`onVisibleChange`。本次将依赖升级为 `~2.0.0`，并将 Tabs 溢出菜单迁移到 `open`、`onOpenChange`，保留内部开关、键盘导航和选择标签后的关闭行为。

`MoreProps` 直接继承 Dropdown 的类型，因此对外的 `more.visible`、`more.onVisibleChange` 也随之移除，调用方需改用 `more.open`、`more.onOpenChange`。这是破坏性 API 变更，应随 Tabs 新主版本发布。中英文文档已补充迁移说明，未增加旧属性兼容逻辑。

### 验证

- 使用正式发布的 `@rc-component/dropdown@2.0.0`，全量 81 项测试、3 项快照通过。
- 新增 `more.open`、`more.onOpenChange` 的受控状态测试，确认点击只通知变更、实际状态由外部属性控制。
- 类型检查、lint、编译和样式构建通过；lint 仅有原有警告。

关联：react-component/dropdown#269。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **变更**
  - “更多”下拉菜单现使用 `more.open` 控制展开状态，并通过 `more.onOpenChange` 响应状态变化。
  - 旧的 `more.visible` 与 `more.onVisibleChange` 属性不再支持，升级后请同步迁移相关配置。

- **文档**
  - 更新中英文文档中的属性说明和使用示例，明确 Dropdown 2 的新属性及迁移要求。

- **兼容性**
  - “更多”下拉菜单的受控打开与关闭状态现可正确同步。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->